### PR TITLE
updated the LIL package and removed the error

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,6 @@ The output should look similar to the following:
 
 2022-12-08T14:58:54.612Z [WEB API] info: Express is listening at http://localhost:3001
 ```
-REMARK: Should you receive following error message
-
-```shell
-`src/algorithms/Naive.ts:66:51 - error TS2345: Argument of type 'import("C:/temp/CLEAN3/ldes-in-solid-semantic-observations-replay/engine/node_modules/@inrupt/solid-client-authn-node/dist/Session").Session' is not assignable to parameter of type 'import("C:/temp/CLEAN3/ldes-in-solid-semantic-observations-replay/engine/node_modules/@treecg/versionawareldesinldp/node_modules/@inrupt/solid-client-authn-node/dist/Session").Session'.
- Types have separate declarations of a private property 'clientAuthentication'.
-
-66     const comm = session ? new SolidCommunication(session) : new LDPCommunication();
-```
-
-Please delete the folder `node_modules\@treecg\versionawareldesinldp\node_modules\@inrupt`. 
-This is due to conflicting dependencies and 
-should be resolved once the `versionawareldesinldp` package has been refactored.
 
 ### Properties file
 Below you find more information properties used in the `replay_properties.json` file:

--- a/engine/.gitignore
+++ b/engine/.gitignore
@@ -1,0 +1,2 @@
+/dist/
+/node_modules/

--- a/engine/package-lock.json
+++ b/engine/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@inrupt/solid-client": "^1.23.3",
         "@rubensworks/solid-client-authn-isomorphic": "^2.0.0",
-        "@treecg/versionawareldesinldp": "^0.0.2",
+        "@solid/community-server": "^6.0.1",
+        "@treecg/versionawareldesinldp": "^0.2.1",
         "await-notify": "^1.0.1",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -25,6 +26,17 @@
         "typescript": "^4.8.4"
       }
     },
+    "node_modules/@bergos/jsonparse": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.1.tgz",
+      "integrity": "sha512-vXIT0nzZGX/+yMD5bx2VhTzc92H55tPoehh1BW/FZHOndWGFddrH3MAfdx39FRc7irABirW6EQaGxIJYV6CGuA==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -33,696 +45,2172 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/@comunica/actor-abstract-bindings-hash": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.22.0.tgz",
-      "integrity": "sha512-3Yrupl0AUFcPtxjImzvPSx6ygCgiJ4Ss0rFIhTuNRvTJohhYc/VpmPjqdprhghtHnhfmIEcqgb7TqdwqlntR2Q==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "canonicalize": "^1.0.1",
-        "hash.js": "^1.1.7",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-abstract-bindings-hash/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
     "node_modules/@comunica/actor-abstract-mediatyped": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.22.0.tgz",
-      "integrity": "sha512-+KQLPpx8GFqrhWFfuvrsA4Rjlfbo/QOIo2IvzSgmDwy6YVQZXaSQiNQv/BnrnedaFCf2ONV+w+PMLqXgzn8N9A==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.8.0.tgz",
+      "integrity": "sha512-UuqvlLmbGZKUnEfb9li7bzzLrL6fo/xSEIH0ZsLUj18ezcPMbEouRitK0rX+vgkRIQ+lrSP+bZ0vV7OWjizj8g==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
       }
     },
     "node_modules/@comunica/actor-abstract-parse": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.5.1.tgz",
-      "integrity": "sha512-KbkdI2QRH6gfVsDwufpj02jBSBMSG19xC1d52M1GG6MfdMoDNj2MLlcf0rXgYe1IePdCWf0qZzxqdu4fYQpYFw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.8.0.tgz",
+      "integrity": "sha512-zWxS4/dJSRU4ZvAYQeNmOVlCwVAqYs4+8ODGp1WZz04BwQvJ+dYld4m8mWei9roT486YRoZDTfWayEKTwmk9tw==",
       "dependencies": {
-        "@comunica/core": "^2.5.1",
+        "@comunica/core": "^2.8.0",
         "readable-stream": "^4.2.0"
       }
     },
-    "node_modules/@comunica/actor-abstract-parse/node_modules/@comunica/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-      "dependencies": {
-        "@comunica/types": "^2.5.1",
-        "immutable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/@comunica/actor-abstract-parse/node_modules/@comunica/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.13",
-        "asynciterator": "^3.8.0",
-        "sparqlalgebrajs": "^4.0.5"
-      }
-    },
-    "node_modules/@comunica/actor-abstract-parse/node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-    },
-    "node_modules/@comunica/actor-abstract-parse/node_modules/readable-stream": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-abstract-parse/node_modules/sparqlalgebrajs": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-      "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.3",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.6",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.6.1"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
     "node_modules/@comunica/actor-abstract-path": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.22.0.tgz",
-      "integrity": "sha512-S7IfWTKWvTTyRDiNb0NApLG1lwh3WKHmmBx6WqI3GicJfS+6kjZqrM2ke5OyVr2R6dpVfu6OnF0TiRYdPVgjEQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-2.8.0.tgz",
+      "integrity": "sha512-JFhAf72zeoWqPUyVFmSha1GpDPawxHu40kLKzsQ1OycNhmtaAh9jylFz0gOF6RMLCZlh8Yr4hptAVecdZRdJ0A==",
       "dependencies": {
-        "@comunica/types": "^1.22.0",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-abstract-path/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "node_modules/@comunica/actor-context-preprocess-source-to-destination": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-1.22.0.tgz",
-      "integrity": "sha512-37aC7WacPIn7yObMubD3QvN0fze9kwBrHDf2M6cwe+54l3uCKYd8jeMH7pJTAT3eSLb32PYU1cxRiwRkQ8gVwQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-2.8.0.tgz",
+      "integrity": "sha512-W4puP9aN27utJeo7a73/uBGJfHtBzXMHIq9Fd3ip1zGODWNCMlz0ab/tci5kDN8wDhZxo920+CqVcVltqztRuQ==",
       "dependencies": {
-        "@comunica/context-entries": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-context-preprocess": "^1.19.2",
-        "@comunica/core": "^1.19.2"
+        "@comunica/bus-context-preprocess": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
       }
     },
     "node_modules/@comunica/actor-dereference-fallback": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.5.1.tgz",
-      "integrity": "sha512-Yn3NFS73LV62QLYYzdGxTAROHr319D2RmNwXxkkz98oVFVkoWsWU+ojIA4n8yjceuHu0jXP5C0NNJIou+dR2lw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.8.0.tgz",
+      "integrity": "sha512-YL31QpzTK9rdJLeARCXqp/EGCHuigqUk+LqeEG3TXHs2ZFK9RYRzqKQe3B43Ak+9KJjoi/i0H11i7UEu8Qdrdg==",
       "dependencies": {
-        "@comunica/bus-dereference": "^2.5.1",
-        "@comunica/core": "^2.5.1"
-      }
-    },
-    "node_modules/@comunica/actor-dereference-fallback/node_modules/@comunica/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-      "dependencies": {
-        "@comunica/types": "^2.5.1",
-        "immutable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/@comunica/actor-dereference-fallback/node_modules/@comunica/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.13",
-        "asynciterator": "^3.8.0",
-        "sparqlalgebrajs": "^4.0.5"
-      }
-    },
-    "node_modules/@comunica/actor-dereference-fallback/node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-    },
-    "node_modules/@comunica/actor-dereference-fallback/node_modules/sparqlalgebrajs": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-      "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.3",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.6",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.6.1"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+        "@comunica/bus-dereference": "^2.8.0",
+        "@comunica/core": "^2.8.0"
       }
     },
     "node_modules/@comunica/actor-dereference-file": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-file/-/actor-dereference-file-2.5.1.tgz",
-      "integrity": "sha512-0+vnQ1KsTuRQRDz3vNSg23ohDS8oyY4zlsSIwyJAj1Ao4I5xhYtrt7h0up4o4hV2Qcy4ILoUGnVJzLaf0zCojQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-file/-/actor-dereference-file-2.8.0.tgz",
+      "integrity": "sha512-HhX+7DVvxc55LnWNFCGBgmObOBXayz8h2ho40LWASnP/IGAeGBxSST01T5ejcOLotBbirlOE1gp9QCZ+DygzQQ==",
       "dependencies": {
-        "@comunica/bus-dereference": "^2.5.1",
-        "@comunica/core": "^2.5.1"
-      }
-    },
-    "node_modules/@comunica/actor-dereference-file/node_modules/@comunica/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-      "dependencies": {
-        "@comunica/types": "^2.5.1",
-        "immutable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/@comunica/actor-dereference-file/node_modules/@comunica/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.13",
-        "asynciterator": "^3.8.0",
-        "sparqlalgebrajs": "^4.0.5"
-      }
-    },
-    "node_modules/@comunica/actor-dereference-file/node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-    },
-    "node_modules/@comunica/actor-dereference-file/node_modules/sparqlalgebrajs": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-      "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.3",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.6",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.6.1"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+        "@comunica/bus-dereference": "^2.8.0",
+        "@comunica/core": "^2.8.0"
       }
     },
     "node_modules/@comunica/actor-dereference-http": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-2.5.1.tgz",
-      "integrity": "sha512-Vy9IyaNgygp5qFB14/FV6bt77JQJgOfEfMopyC2f8KcMWmFHdbuRPVCv83kme4wouB6d6L0mCvQ2yT6uWQf8qQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-2.8.0.tgz",
+      "integrity": "sha512-iVvkCl3i3JCDQEOVFYUO3TMKuIbvn5ByeukZ0kHagYFNd8Buq9iIkxYKJHw7rMeGCmjpF+RekdGl/y7sGTHhDQ==",
       "dependencies": {
-        "@comunica/bus-dereference": "^2.5.1",
-        "@comunica/bus-http": "^2.5.1",
-        "@comunica/core": "^2.5.1",
+        "@comunica/bus-dereference": "^2.8.0",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/core": "^2.8.0",
         "cross-fetch": "^3.1.5",
         "relative-to-absolute-iri": "^1.0.7",
         "stream-to-string": "^1.2.0"
       }
     },
-    "node_modules/@comunica/actor-dereference-http/node_modules/@comunica/bus-http": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.5.1.tgz",
-      "integrity": "sha512-kouDqVoP6qAVQ4pflMmedBHfMtuLoBgqwX3mHdlUtrE0h1I+/EX6M5eUe5pXI6PfJrn3cInHyu+UZkbZYrykAw==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "is-stream": "^2.0.1",
-        "readable-stream-node-to-web": "^1.0.1",
-        "readable-web-to-node-stream": "^3.0.2",
-        "web-streams-ponyfill": "^1.4.2"
-      }
-    },
-    "node_modules/@comunica/actor-dereference-http/node_modules/@comunica/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-      "dependencies": {
-        "@comunica/types": "^2.5.1",
-        "immutable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/@comunica/actor-dereference-http/node_modules/@comunica/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.13",
-        "asynciterator": "^3.8.0",
-        "sparqlalgebrajs": "^4.0.5"
-      }
-    },
-    "node_modules/@comunica/actor-dereference-http/node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-    },
-    "node_modules/@comunica/actor-dereference-http/node_modules/sparqlalgebrajs": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-      "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.3",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.6",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.6.1"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
     "node_modules/@comunica/actor-dereference-rdf-parse": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-2.5.1.tgz",
-      "integrity": "sha512-24u/lt1yJcwAijwJSfOI19L6ZAMmctgyJFrZRjvwPG+g3kl9Eyqw0WdWhKijOj+/bS3nSaQGKL7MlUkYM6VZfQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-2.8.0.tgz",
+      "integrity": "sha512-bMVzK4RBnvmH8lh7jRXar7EXZoTvdYBl8lX+4U9t3djKByv7JUNNx0jRMDfFF6L+uNYy5i4JNlPJt6W0E49Wfg==",
       "dependencies": {
-        "@comunica/bus-dereference": "^2.5.1",
-        "@comunica/bus-dereference-rdf": "^2.5.1",
-        "@comunica/bus-rdf-parse": "^2.5.1"
+        "@comunica/bus-dereference": "^2.8.0",
+        "@comunica/bus-dereference-rdf": "^2.8.0",
+        "@comunica/bus-rdf-parse": "^2.8.0"
       }
     },
-    "node_modules/@comunica/actor-dereference-rdf-parse/node_modules/@comunica/actor-abstract-mediatyped": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.5.1.tgz",
-      "integrity": "sha512-Iz8j1XqXp/A7HJVDTtEtp7hV6nuNoIjjEUgiJUiBTM5OIx7sFbGfUd10VtHPSXB/3lHHcIo34BKNZkeurNo6BA==",
+    "node_modules/@comunica/actor-hash-bindings-sha1": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-sha1/-/actor-hash-bindings-sha1-2.8.0.tgz",
+      "integrity": "sha512-izgsb2WFQSmcbgzjphoFySzfUS3win/FfNPXzf1v9LCx05Yu4tqz9M1ZDu3C1nR1iNrIFFZ7On7Dg2RU0UfuXg==",
       "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1"
+        "@comunica/bus-hash-bindings": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "canonicalize": "^2.0.0",
+        "hash.js": "^1.1.7",
+        "rdf-string": "^1.6.1"
       }
     },
-    "node_modules/@comunica/actor-dereference-rdf-parse/node_modules/@comunica/bus-rdf-parse": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.5.1.tgz",
-      "integrity": "sha512-BzfvedLkh1bOSa/WeUzLc/bQlcXWKhIkG/GwIOrCFtoWJOdOlapWdPvPS5U6sEW/UW454ClRWaqIA+GM0qeyzA==",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^2.5.1",
-        "@comunica/actor-abstract-parse": "^2.5.1",
-        "@comunica/core": "^2.5.1",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@comunica/actor-dereference-rdf-parse/node_modules/@comunica/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-      "dependencies": {
-        "@comunica/types": "^2.5.1",
-        "immutable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/@comunica/actor-dereference-rdf-parse/node_modules/@comunica/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.13",
-        "asynciterator": "^3.8.0",
-        "sparqlalgebrajs": "^4.0.5"
-      }
-    },
-    "node_modules/@comunica/actor-dereference-rdf-parse/node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-    },
-    "node_modules/@comunica/actor-dereference-rdf-parse/node_modules/sparqlalgebrajs": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-      "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.3",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.6",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.6.1"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
+    "node_modules/@comunica/actor-hash-bindings-sha1/node_modules/canonicalize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.0.0.tgz",
+      "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w=="
     },
     "node_modules/@comunica/actor-http-fetch": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-2.5.1.tgz",
-      "integrity": "sha512-2E25qKw2+16iWOHfaaGkbzv14owMwN3UGWURPaLyFIOa8S6xkjU/8CMWRjaGibee2KOC8TKUioeQ+YJCweIC/w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-2.8.0.tgz",
+      "integrity": "sha512-Eqdkx2SZHdJ4GJeO87jslUCVMUEhi+hvUbh9Hstvksf0aShN/SNBzjfbEITBUkbo15WR5ZdFd4EZDLKBs9yTvQ==",
       "dependencies": {
-        "@comunica/bus-http": "^2.5.1",
-        "@comunica/context-entries": "^2.5.1",
-        "@comunica/mediatortype-time": "^2.5.1",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/mediatortype-time": "^2.8.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.5"
       }
     },
-    "node_modules/@comunica/actor-http-fetch/node_modules/@comunica/bus-http": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.5.1.tgz",
-      "integrity": "sha512-kouDqVoP6qAVQ4pflMmedBHfMtuLoBgqwX3mHdlUtrE0h1I+/EX6M5eUe5pXI6PfJrn3cInHyu+UZkbZYrykAw==",
+    "node_modules/@comunica/actor-http-proxy": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.8.0.tgz",
+      "integrity": "sha512-03ltsJrhYnBEc7TwTEHe99KdsCnG8x/XkaA3jeiG99co+xxrbNgjgNJLOZl8aA08Ogaur1Sb+UuiCB9jrSLRxA==",
       "dependencies": {
-        "@comunica/core": "^2.5.1",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/mediatortype-time": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-http-wayback": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-wayback/-/actor-http-wayback-2.8.0.tgz",
+      "integrity": "sha512-Iam675J8f08CJfIbXjJs2coZxhXan+K7q18+DMv1veuXXH3Wrh1x7g2EcH8vdDH/G52bG2oZ02KsodWGvLVz7g==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "cross-fetch": "^3.1.5",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-init-query": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-2.8.0.tgz",
+      "integrity": "sha512-Zd2SlaCiZZ3inEQHvXgX1MIjQDUWsqkMEo2MQOUYibHGDvjdGxUDJCmc3TYBv+I3wdjH+991GVSsSS+mFB+DAQ==",
+      "dependencies": {
+        "@comunica/actor-http-proxy": "^2.8.0",
+        "@comunica/bus-context-preprocess": "^2.8.0",
+        "@comunica/bus-http-invalidate": "^2.8.0",
+        "@comunica/bus-init": "^2.8.0",
+        "@comunica/bus-optimize-query-operation": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-query-parse": "^2.8.0",
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/logger-pretty": "^2.8.0",
+        "@comunica/runner": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.13",
+        "asynciterator": "^3.8.0",
+        "negotiate": "^1.0.1",
+        "rdf-quad": "^1.5.0",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^4.2.0",
+        "streamify-string": "^1.0.1",
+        "yargs": "^17.6.2"
+      },
+      "optionalDependencies": {
+        "process": "^0.11.10"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-bgp-to-join": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-2.8.0.tgz",
+      "integrity": "sha512-3ZIRLI0lFSLy4QDW/ml8I4je/d6zr+jnI1sMOfkVibpxAWfKXxfgB0IVCpTheiSYVie3SycBET77Q9fwQpidyQ==",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-2.8.0.tgz",
+      "integrity": "sha512-pmH0WRPQOQyu2ilD01EZmJn2gSTCmDFjw/H6IBCTSLH4umvaka3i0Duu5vHhw/1FpHi8juY/z5MotraoIMObjw==",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-join-connected": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-2.8.0.tgz",
+      "integrity": "sha512-mk7BE743NY6KcgPuP1jIj7n5/zR0KmUCtPh3/Odi0PH435PlbdQwjetoWpgeUMTrn40r4dsLzIfqPNBplAKIOA==",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-ask": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-2.8.0.tgz",
+      "integrity": "sha512-OGYRBI3w/YX9PcII8M4HICERGtnRWBlbLcTZlA8YIF2qBtOPIKqMYqg/GRiCmrgaoNVut6xRDYtZ8TW1pVkjHg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-bgp-join": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-2.8.0.tgz",
+      "integrity": "sha512-W0BUxlfO8HEnmBKB+8J1kPQy/j1OA1xn3NIXL0kyIorTv3g7bIXHRac1gr/gRzAkqvKCFYQ2KPwcu6wQvZnGUg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-construct": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-2.8.0.tgz",
+      "integrity": "sha512-I0pc1pxNau/MfdLcfo6Q3ihVDY9f6PMmEGseJtM9KMsMRyl8mPmfIkb7o9JHul5Uw+89lg1jmuEXBU/RGQx7ig==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-describe-subject": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-2.8.0.tgz",
+      "integrity": "sha512-ZrvfwX3wtATZqGwy/oUXrwiKlc41+aWYmU/aD4O7mZ358PcVDu/4VND8cySModfYHM78tXgeU8dHOntheoQZlQ==",
+      "dependencies": {
+        "@comunica/actor-query-operation-union": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-distinct-hash": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-2.8.0.tgz",
+      "integrity": "sha512-LFxDeDovi8lHnSCDwIzVZztqlK4Ph4PNSvNILhIOCc7RFr32ljxzvivw7s03ePVebxDhCI/Aqm9c7bm2ndM6Ug==",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-extend": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-2.8.0.tgz",
+      "integrity": "sha512-4Dlut/Eg/N9+43fWWX0tQNNPvfq0oTx8YXp7pcZXNVhEKAVZ/kjZCQo6S3lu9TkItefyonLWgHg/leuSqu+GUg==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqlee": "^3.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-filter-sparqlee": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-2.8.0.tgz",
+      "integrity": "sha512-gGjM9U090TUd0VIN0NIH9EcBupNh5TYq/EEXLxYWbwK+DjyBYk0zN2En/6HUCcM+tFYlPfj264m1g/9V2gzWwg==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqlee": "^3.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-from-quad": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-2.8.0.tgz",
+      "integrity": "sha512-7rpan2gvDmWGr57B7gIi2I1Vva0cXuYQG2ZLE9aEA6HGzqHtd37a9zhmURyUOSXm/VGWTVtBrQ/UqhSFFLLRkQ==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-group": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-2.8.0.tgz",
+      "integrity": "sha512-n34wfdnvJ8b3DspNt4OfY2jREtPoghSleALRdKww15pXY2zyGFSyigKL5lPI+KyM4i+c/htKQz+ZruAPG7/nFg==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-hash-bindings": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqlee": "^3.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-join": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-2.8.0.tgz",
+      "integrity": "sha512-2pGRJqY3rDHkX9tbGlAQWHOnOlQcI23j1IwKQSJCgOfmoq2TG21fde4sL4ehpoaF78P0bwhQKiYIJai+PZE0ew==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-leftjoin": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-2.8.0.tgz",
+      "integrity": "sha512-e6z/M3/HNUdJZ8ISvvynBaOib8aSEhwYTM7fj5ctCr38vP4pb4cDkxtsTpI3Di4jTgOGQ96Tl7SR3dEXzctqvA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqlee": "^3.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-minus": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-2.8.0.tgz",
+      "integrity": "sha512-OeVn6UvLd+NljSPsPjIDGSKjbe/nR4Aq4Ps2iudzAw4SNiw3x03o21DMIHxNSDvPVuAaYQJq/7LyeCBvUDrq3Q==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-nop": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-2.8.0.tgz",
+      "integrity": "sha512-GqtoM1rXmplAaaBMtALbtYbIvGUlPipycYJxlzHTkXTlBJHkikBUJb8qL5W4LAWm6yZ60l1nFYmtwb6ueifXGg==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-orderby-sparqlee": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-2.8.0.tgz",
+      "integrity": "sha512-EgtEEic3vKT8EZw5NpqsV0NMzk4nwgng/gKwGQGezc2D3ZmCJv/Cho/f2E/PpuBO7s7/mJ9OmeyxNGTLY0SDJA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqlee": "^3.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-alt": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-2.8.0.tgz",
+      "integrity": "sha512-9qLMSax4hNKFUFJtmNE1/Gtu4Qc4Y3KVGqLj6q09mEODB+9IXMsBXtvXJlBLxfG9I0YwI/NC4fZudKMeAmw5zQ==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/actor-query-operation-union": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-inv": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-2.8.0.tgz",
+      "integrity": "sha512-rbvkIoKgQHp4hff19Rrcf2LLvRMa3gibtDMk5G3bi+3GIPD8TOBI6e5ZBsOz3jQLyEAcRcHurzipeGWC/1gPFg==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-link": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-2.8.0.tgz",
+      "integrity": "sha512-eCruNrzExWKb2SaAQBYIPfMjsq724JE9vwUm2FimJD+9UqNnMKkO9fkNdwcWzzPQuwG7XVJGIaOKE1kpO+zl6g==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-nps": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-2.8.0.tgz",
+      "integrity": "sha512-VO0ThXhRviHvZ12D7rL4ooulwFp3fZxiTLblRqg9sE8pbpNzocOTfgIz0C06kXzEdQNl33ztHQ3DCvFCeyI9cw==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-one-or-more": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-2.8.0.tgz",
+      "integrity": "sha512-vQ1UcY4EysELBVfXtHs8m6Macp6XHWsYVEkn3o/Dln9Rj7+gQy3rqHFmCWwcK0lUaldiugWqhK/wiMxpe7ZFZQ==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-seq": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-2.8.0.tgz",
+      "integrity": "sha512-uH/dUaEaM5qBb3T/UoAxuVuf1AI3R3NuDzWKPytsH3EgTPz6Sl4QfU8wFcofVI4NYn3bptnoOf19eInWmbnMIw==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-zero-or-more": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-2.8.0.tgz",
+      "integrity": "sha512-zbylKeSK3uEyFf6co40i8QmR9o+WHq+1+R0A8KczymI7snNkzGdz9tIY7NKAGpAtg9fajPg3cXzj5P7tJyMpIg==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-zero-or-one": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-2.8.0.tgz",
+      "integrity": "sha512-1pR+UqROcBwItctc4z/Vjxe2EUovU7RbYBkAi9mmtxt0Zn6v6xK54c7zPZy7VwmadZXuUsLgjb0AgS+2RZr34w==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-project": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-2.8.0.tgz",
+      "integrity": "sha512-xVhoEPtxDP61Y0twg2uNj3jEotfjFASFwv6uHtXhpUTrWYKHBiYUsYIrA0FyQpFJ/QzuytY7Ci46RWWUSRqz6g==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/data-factory": "^2.7.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-quadpattern": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-2.8.0.tgz",
+      "integrity": "sha512-jwxNcbf6+f1/Zrc8J9GY9VjsjU7h6f9+gX/O0xmGnU8XKFRWwtHjlRe5Bfw7o/r4PDWtpTQ62vfko9U+iJqe1g==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.3",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-reduced-hash": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-2.8.0.tgz",
+      "integrity": "sha512-m0b6xRY+cKxajgqwX2Tvc3XCXlj7aEfHamolMRGK9sKN5nuj4GzU05CNRKo+2wXoHLLmMMF+B+dGk+kg5gc5hg==",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@types/lru-cache": "^7.0.0",
+        "lru-cache": "^10.0.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-reduced-hash/node_modules/lru-cache": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-service": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-2.8.0.tgz",
+      "integrity": "sha512-9BNCoSEbzh08anvOKEXex1XgTacqFWXmxsKIeM+sr87/H7iS+UhWLcmyqYL9IrsjfkjMuWW6h+aNTVrqwJeAUA==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-slice": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-2.8.0.tgz",
+      "integrity": "sha512-BotGylGuWV8YuGeWaP8UpLekIEmQ/X+CebySORL+/U/+XULBDgyx7d6G0ThpUBG6p6YWyE9V6X4Bhx07EFqEjA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-sparql-endpoint": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-2.8.0.tgz",
+      "integrity": "sha512-cgogW7drbUiBffggtJT3ulDyQbfC0b0qpJ/Eb4sAMs0r/xYssK+BQejjJd5pfeunDPOve3v82yMAyso/mq8I8w==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/mediatortype-httprequests": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "fetch-sparql-endpoint": "^3.3.3",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-union": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-2.8.0.tgz",
+      "integrity": "sha512-VB+1T+Q1VvPoO6GEWEstzlxALNCoreCo9UFp3c6fliNUTGvl1dIswGQUO05IJd447tGbe4jnNkgtB4Jz/dTLSg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-add-rewrite": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-2.8.0.tgz",
+      "integrity": "sha512-12ul+wc6MQ+e4RPHNBj6jpsdkB791sckDZOZM8kZXQVPMlg+lFFrU5o2HQsk5oB8oHlwEMiGXXKBY/vig8zStg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-clear": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-2.8.0.tgz",
+      "integrity": "sha512-Jfxys4fzl7NHb5zEwXaQuGa89kbWn9pRwv98qmDFdPyzWm71vh4/1yxVOyK579tifLFOtWzfAHPnnPrGAfkDgQ==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-compositeupdate": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-2.8.0.tgz",
+      "integrity": "sha512-cIjX4ATSXqAVu63aqkOg9ON67Z+9jefVTy6Sk4ATymRewZmxoZG53krNpwAB6ox9NZ6QF5EfN3p3By5rJeG4Qw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-copy-rewrite": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-2.8.0.tgz",
+      "integrity": "sha512-N2EpVCzwVBtcQmptjZ3+psRE0UNQUqQLln+1VOCE4dEfqAuQ47c2daBagHbIEVnSri1N/1rlxMRDPk+TcF/CAA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-create": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-2.8.0.tgz",
+      "integrity": "sha512-usuaHdvEIqDa8BowmeAG7jfpTuy8wft199KOXUrxKfEIsUWppWeZS1TlfDLKIGdpAr/h+8rpl8wDcztMElzLKw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-deleteinsert": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-2.8.0.tgz",
+      "integrity": "sha512-beIFoi6J8hIP5nHcl/iFJqwa1bfLXMcbtHLphV3SyEd/UDr5a/hJct9oICUdMDbgm1MDUUhUUky3Rmwe2pWCTg==",
+      "dependencies": {
+        "@comunica/actor-query-operation-construct": "^2.8.0",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-drop": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-2.8.0.tgz",
+      "integrity": "sha512-jhonibTxM/H9Psj0DfzH+VWkxzaPDvjJU9iHISezPOJl1hn+e+KrQ2RF3A8qqzKTsG3l/M9hgklZU4X1cVs66g==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-load": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-2.8.0.tgz",
+      "integrity": "sha512-tq973bYqQP2/ivNxBZgjYwVkroQfWA4pr3WMmSBF726OrwuQ5csqpHRrFy8JcsybAMgMTxpOp3CmZRUdUKmtyA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-move-rewrite": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-2.8.0.tgz",
+      "integrity": "sha512-bcKo6pZ/FtR6NfThBVaFuHh1WolGyR8MMWJfWKOUumcsxkHb5uzQ6V/hVk59Z/DFfSiuRuS1kDSWtv12RjT5Og==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-values": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-2.8.0.tgz",
+      "integrity": "sha512-3c/by7iYOdXCqLreX6rBsIzNQFz6i6U1WMQnULWGvvuwMtqiTGd5GYhT+X6QMaqCk+1WNvG8F4hZNplAWE15Ig==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-parse-graphql": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-2.8.0.tgz",
+      "integrity": "sha512-yh+fqzNJE61weqfK1bbBXrGP650CE/VqPg10WaT6yO6+tlyYa3d42en5N/2TlqB8gVmCoYH4Ymz6GqSEJGHVPw==",
+      "dependencies": {
+        "@comunica/bus-query-parse": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "graphql-to-sparql": "^3.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-query-parse-sparql": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-2.8.0.tgz",
+      "integrity": "sha512-jV2o/5gyx9K/vE8ceAddrrsjlDOWo0FsqPFVELBRyYxyoLn59gFNYk5iqLCCQYCmPda69mip1VwkCv6+J7EyVg==",
+      "dependencies": {
+        "@comunica/bus-query-parse": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@types/sparqljs": "^3.1.3",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqljs": "^3.7.1"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-json": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-2.8.0.tgz",
+      "integrity": "sha512-Fgw/fRH12qr/gE5iEpAR7ttnAk6clHSEjbUqkAPswe+qkxALlMw7IfcyoTACQFP1WeSrs24udNXTjRjEDXCA+A==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "rdf-string": "^1.6.1",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-rdf": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-2.8.0.tgz",
+      "integrity": "sha512-BP6umNugwjiUS2WfChkA5RfrubSlpjOXCQVmYkR6YA56ZjNfKNnZVZnkl9BQGd4cz5Wgd9n0IXuSq8mgx3UDEw==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/bus-rdf-serialize": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-simple": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-2.8.0.tgz",
+      "integrity": "sha512-vjjGWzEiVw9P+30c3gdJp2/Y+Qpq8U+UP2xFFbmbnGJ0kqQQUvxBNSZ9rwxm/j7hY28PMwV7ELEB1PODC90PYw==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.3",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-csv": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-2.8.0.tgz",
+      "integrity": "sha512-EZw541247FBYqP3xrI4e3RDT2PEajlXK86EFHMyBeJGdzEuaRuVOEYtsdWS9KEzQdsoYbfIrdQSvTaf9LQSOaA==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-json": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-2.8.0.tgz",
+      "integrity": "sha512-K3nQZB+JOlnEaRSSH+FJbZdOHriq+hcUnY0rwOiyk9L95MWrr70nCGBeSLlp4kJ84CxmavwA7w698HXAKGUTfw==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-http-invalidate": "^2.8.0",
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-tsv": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-2.8.0.tgz",
+      "integrity": "sha512-gKj+JehBXipvx9uz6zTUtxB/8REjEP7KCtA96et0qlM0vP6ZdKdav7jdvjG4443lWJyUKh2Nm+gxG3oXrwTzuQ==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-string-ttl": "^1.3.2",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-xml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-2.8.0.tgz",
+      "integrity": "sha512-CoVrtlH0Emc6DaCPmcRLhASK5hh3SN/+3NHxpuTYJ6NtF7S8U7EtGzNi25dPgL0EYZM4Iql8r//Tnb+TaxS5TQ==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-stats": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-2.8.0.tgz",
+      "integrity": "sha512-c0HhqLUl2gMG8Jvf/uGLQNy2dJQUPc6XsDZiwzskKjBrmjXk1bUKwQIy/sa0s7ch2VUGr8RjdmLEZw4Dsq3ZAQ==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-http-invalidate": "^2.8.0",
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "process": "^0.11.10",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-table": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-2.8.0.tgz",
+      "integrity": "sha512-XorIgM7nWYi9KNxkAv3wj8Wz7SUuYl4PHts1uRMetCUOgVRak2mR8IeUsY8LaGugBwLdvXXKxGOCkIZttX5Vkg==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.3",
+        "rdf-terms": "^1.11.0",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-tree": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-2.8.0.tgz",
+      "integrity": "sha512-0HtJ831i1CWpBq8JBI/F+zUnEkGEvbYZj91CoaHFWbkLhjdmmENp25O3ro8jkkcJMKq910t7IzZbBzwCK0+8OQ==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "readable-stream": "^4.2.0",
+        "sparqljson-to-tree": "^3.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-entries-sort-cardinality": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-2.8.0.tgz",
+      "integrity": "sha512-LmK1iqykzkX1C9LZ/BXQv318EbqFwnW3iymDYS3zOtkborB9QSdfjV9p/27mxGYjj2Ahv0zxQtU2G++gSfcKeg==",
+      "dependencies": {
+        "@comunica/bus-rdf-join-entries-sort": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-hash": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-2.8.0.tgz",
+      "integrity": "sha512-TXXeyVTFVKZttkrG2YZuDLHD+IodlDN7/uulxATkKk4t+XZu6k4n3cyibuyhQ1oq3ftVYokejijfTWCkNLvcYA==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-bind": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-2.8.0.tgz",
+      "integrity": "sha512-lwGQ3MTd5MgNps+lsAV2otaC5SpfGPSYkJTHQnEuQsB/Nr1ikXZqrAV0xt7Z/tfXDp9QSqn4C/EbVq4oogpU5Q==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/bus-rdf-join-entries-sort": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-empty": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-2.8.0.tgz",
+      "integrity": "sha512-SCJqhN2a4Abs5KC6woNHiT/rORlUdeYrkNn/VRUzPsr9L7DB9lnOus7H1OBUCh2MZPZgKZqqj0YXeekEDrbfWQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-smallest": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-2.8.0.tgz",
+      "integrity": "sha512-YtiJ88FEVY9+RZtG8J/EQtQldJch31Z3/G6RaAUmG5HM97aV/Nk3BCoqtGcWahFwnOPxfbmdMhgXfvLA8Wc9Eg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/bus-rdf-join-entries-sort": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-nestedloop": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-2.8.0.tgz",
+      "integrity": "sha512-2iw5v0kWnRsrGsyzUgDvGcfhnKNLAAkTk+DJ1zeVJJgNjeRWbxrxyOwHyySxz66KOxw9saylUVDOxqrWsZkgiw==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-none": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-2.8.0.tgz",
+      "integrity": "sha512-ItujqMqGpJ7tBH4/7inzBWCgm6O6IjXw4CSfMcd8sX2XlPWt3Kh8rNgp6zZtIHAm90q9us0pZZqTuxt0U8LtDw==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "asynciterator": "^3.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-single": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-2.8.0.tgz",
+      "integrity": "sha512-+CN4dJhJYFJMmLLkLaQOE26qVigYhVhqGa+DFB5B6liR9bKHDEytktOSgSwaBR2oPUifjT7eGshDj9ZdmbB3dg==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-symmetrichash": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-2.8.0.tgz",
+      "integrity": "sha512-vuWbVsWKshBExfOor1yIeNmxqdBHZZmMndMjyj5acRX/QIWNb2XS17HcTP1z0BC22yvl4vm3HyvZ6ksbOTKJLA==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-minus-hash": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-2.8.0.tgz",
+      "integrity": "sha512-5lkzyk/jhkusyCltnyR7u17qS3roB9Fr6L3W/3Vbmmv6HbwlA2FvJ/qy5+8jX2wn7rWAb8bGRJdHi4BiOnFHFw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-minus-hash-undef": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash-undef/-/actor-rdf-join-minus-hash-undef-2.8.0.tgz",
+      "integrity": "sha512-C3sqL4mWcAozLUKHXTPD9gsdePVnYwze1s1Tn4KKHv1FBurckcV/jGCUgavyK4Bh2yURXzSA3yXgYyz5LQraWw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-optional-bind": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-2.8.0.tgz",
+      "integrity": "sha512-JOPDu2nFpYeBy8xL3pSaDIUawykYmQaYFRbVLnVAFJc+bx5VE6WbH5s7kCwfOBYGCYNDa7xrauC3Dv2Vg55KVA==",
+      "dependencies": {
+        "@comunica/actor-rdf-join-inner-multi-bind": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-optional-nestedloop": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-2.8.0.tgz",
+      "integrity": "sha512-LXYK6iQgdT3rGB0OD17DdQTNX2VkiImzHAU6GHswdPqOrEzlPtveDSueaFfte8B30znQymV53LLLtMxvnPUk+w==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-selectivity-variable-counting": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-2.8.0.tgz",
+      "integrity": "sha512-cSJgvxGxwqlueDqBhzDd/NNysq2TgfIalwWMP3BxZXTshHN+bhfaGEZr7Jp/NRG3zPbnadWS+pqaRFCSmir6nQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-join-selectivity": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/mediatortype-accuracy": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-cancontainundefs": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cancontainundefs/-/actor-rdf-metadata-accumulate-cancontainundefs-2.8.0.tgz",
+      "integrity": "sha512-s8zPBHiUIHQ4Ofsnip/mb9Fqg22mJvB9A6slch5z7whkWYVk+RLSQLxEQVjhb4/9cb6Bq6jof5mnQKYwUKbRKA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-cardinality": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-2.8.0.tgz",
+      "integrity": "sha512-9SnfQjU0yfw1QNf721ygevNP3ElTFK3+YwQgmGHdh5Qx2UE9zCwHYO6tPb55y10rVEwiMojC/rLY3KDLEVu2mA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-pagesize": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-2.8.0.tgz",
+      "integrity": "sha512-1gycVMGGTvRGmOl8Z+9CBFaMVDfkcm5VwmO1WRbfqfoWAdvMYjMk0DOQ8mFbK+Z40ez9LQ8rJh6EyNTVMM3rgg==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-requesttime": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-2.8.0.tgz",
+      "integrity": "sha512-iZTGdAxUU2fIImuRs4UQVYXzukMavyfM+ThTHSPv88/jh1AmmPh6eVc+zrUuIZhP6rGpoVRBLA9ObfinzGM2Mg==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-all": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-2.8.0.tgz",
+      "integrity": "sha512-GTzaNGQS9SaexmWsxWhqSfVLKHCKL/X8W8tXBMxgwBt29NtPGPqM/7avZJ2MI3zhvkvum7OjlWR4E7deNHhLUA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-allow-http-methods": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-2.8.0.tgz",
+      "integrity": "sha512-3YBQ4473M3SicJYtq1IqBCqGqMQ+/r2Qv1EqJWf57u41AROULxB+7M2eerJe5mtZEvD1NYhaxJ3oBX97iVTXvQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-controls": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-2.8.0.tgz",
+      "integrity": "sha512-QQrv/6Gi910rPgk725nwt/NcViGKIA7Br3UfovraRQKOlNKT6qH4/CJxRKHvy5l9gbvaWW/1hrOYhO835H7eUQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*",
+        "@types/uritemplate": "^0.3.4",
+        "uritemplate": "0.3.4"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-count": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-2.8.0.tgz",
+      "integrity": "sha512-mD+hO98676rG63BLMDOibtgDSYkT77aEzWEllsijnnNkQhe29PRH27DhEBbOPgAoFYIYmdzaGw9X+rVI0b63UA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-pagesize": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-2.8.0.tgz",
+      "integrity": "sha512-pAnV5Ddb4ouN+R1cTxFIfWqPxMgofC/zqlwrX515/oKihwttWIHlBXFBdDNG0+yw4fdLUCWW5Usw7CTiTihAYg==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-2.8.0.tgz",
+      "integrity": "sha512-VaGD7VH51O9smipmWHVf2xqDy8+2/kyIoX5E6q6oCP1sZVrrwY1Tz8oK0dCS1FamwzlQGUMwj5XW5sXVWRMvsg==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-put-accepted": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-2.8.0.tgz",
+      "integrity": "sha512-VMxzAVtNP4iiKH58NFsxo4O3I6N645jg8TAEv/F/iMK71IzxSxBBNv9dTUMc3EpXqB2USJPor22WzKN6xa5+xQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-request-time": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-2.8.0.tgz",
+      "integrity": "sha512-w/9uBJd0BJsqJHVuPQVl5BrZ3SPKQcPVXQ6kgpBJBv2i9vo0oJSakp3ISivGYzCG/CtvdDupUc5dNhXD8qwckw==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-sparql-service": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-2.8.0.tgz",
+      "integrity": "sha512-m1PjQ+fiQq7h982daEA2jVdj3OEypy8mavM4GsfkED+9kAtycTJeFaa8FTjFacfp36EKP4K/BWh0FsvRhAY5Ig==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "relative-to-absolute-iri": "^1.0.7"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-primary-topic": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-2.8.0.tgz",
+      "integrity": "sha512-NuD7rMBif6rZkd/XyPolIKtkAEZ5gi6WmbTYur+4X2UaO20MWK5b+28nsN35OvUVQ0OiCuiLtrlZtRP5AjpOkA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.8.0.tgz",
+      "integrity": "sha512-/GJoBkHAJRdMx/VnVulutuTrKOy4Z26SzqlvUFsWyLzWoee8MT9izltG3QO1huHvbj0gePdczPGxtMt3rVihNw==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/bus-rdf-parse-html": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "htmlparser2": "^9.0.0",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.8.0.tgz",
+      "integrity": "sha512-NOvEwrM0didm8caSM7QWbm5WFYu4beMhf5WLzX4yaCmm7r5hK/ObP2EVVripSUw/CKu0PZbgWVmZAdR1H4qlPg==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "microdata-rdf-streaming-parser": "^2.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.8.0.tgz",
+      "integrity": "sha512-KY7DI2OChT8rFFXtUWccPc7nSyhsM5xjIlQnumpBWpF9Px/ah2djVIe0hPcoJnrhlIqjCtal6yEUHItRaX8ERg==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "rdfa-streaming-parser": "^2.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.8.0.tgz",
+      "integrity": "sha512-JnriW7bTOvWtbgkwPsCjr6sQKfEk1ms4uR4cB1ril5md3Grn7CquTDz1keT5Yb12qO0gRF4pJbV0Aw02TWkcug==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/bus-rdf-parse-html": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.2.0",
+        "relative-to-absolute-iri": "^1.0.7"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.8.0.tgz",
+      "integrity": "sha512-b9RYIsUYG+9wUOWeapfc0G8U+pHzv4AyJaEHjlf2S3XHxd3O3GfwCxc7532NHURG94sIu+uWDvwjUtS9PUa/NA==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "jsonld-context-parser": "^2.2.2",
+        "jsonld-streaming-parser": "^3.0.1",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.8.0.tgz",
+      "integrity": "sha512-VCwmD1mpgiD3jQ8g6DF09VMFWSWxOKWfQ1mtLx64Oy+czTyz6tgT4n6w+cyIFFzFtDDoVgX1hknrCODU1kX0vw==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "n3": "^1.17.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-rdfxml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.8.0.tgz",
+      "integrity": "sha512-slefbVFQFNdikRcjnrRMHxsbXznHiQvOg4nQNA310t4Q4NSegfePI/6I06kTJ4/SvkGtWgsFoYIsHINuOvqqVg==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "rdfxml-streaming-parser": "^2.2.3"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-shaclc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-2.8.0.tgz",
+      "integrity": "sha512-+R/h9GUoFXcZ2S3Ku1PrSAdYRVHjws3eE0Go4m2CFiBswW783/1lwKDx0FLO4xGO9ixw+EgstmciirTj5O9nTQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "readable-stream": "^4.2.0",
+        "shaclc-parse": "^1.4.0",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.8.0.tgz",
+      "integrity": "sha512-+Xg6WKWjLTYysogw5x1Savyt3ZFYDmmIhPyMpAyNqfFplHZC3QoON0kKitZ81SC7fiTRpwcyDLYC6DkKBH7DxQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "rdfa-streaming-parser": "^2.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-next": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-2.8.0.tgz",
+      "integrity": "sha512-IcDuQjO6HwwOmM1aEYpeX4UcVcZ5wM2wSkyobFsicMQWM41mlDxwwXqYJqS1TcbW6TqOEzGBStSUEYlyyN9+uA==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-2.8.0.tgz",
+      "integrity": "sha512-nvgTKJc6T0USuPbvB8nfc9tzqy4fNKAedgbsIso1B9yYr7gfH0ypA0Lbc5l+GBiiOaNjQskyAit4zFF6Nz55Pg==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-none": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-2.8.0.tgz",
+      "integrity": "sha512-K1TBuH84CPjShDRa58pqthagno8DcAARlkmN/08U4s2AdojR/Hc2kxMdeXym4vLCWxfw/7GVYglNmpDlYN6vTg==",
+      "dependencies": {
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.8.0",
+        "rdf-store-stream": "^2.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-none/node_modules/rdf-store-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-2.0.0.tgz",
+      "integrity": "sha512-FKRsA5XUdhFVMx+jg4JCBM76B4ZcXVKyilr8GJrlfkHB2IZSIgLxY2XHIsewkDfm/yAtXHvPT0PaeQg4Mbqa6g==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-stores": "^1.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-qpf": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-2.8.0.tgz",
+      "integrity": "sha512-3I4VVfnpnL5rnP5b8LMXdD4o9+mRCzhUdT0arhBc2noUvqhC2QX7bbLXojPC/2/DyHGIWhYA9kZx+j77e5j5Hw==",
+      "dependencies": {
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.8.0",
+        "@comunica/bus-dereference-rdf": "^2.8.0",
+        "@comunica/bus-rdf-metadata": "^2.8.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1",
+        "rdf-terms": "^1.11.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-2.8.0.tgz",
+      "integrity": "sha512-OBlLDNeLG8BD3gdHEmzryhiOBU5/ylTPFLG9CwFDh3NFpHhqoyT0YB0QLrpyp/hg4U22qMtRkt6enasycHsIRA==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "fetch-sparql-endpoint": "^3.3.3",
+        "lru-cache": "^10.0.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql/node_modules/lru-cache": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-federated": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-2.8.0.tgz",
+      "integrity": "sha512-bQkA3PfYXtpUlq5+y0wgYtMRhztp52lSq7riSQZHnmMtkbl39YCNXk15c0aKj03Ec0uz/ujnf+oO0rBPz7/U3g==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-metadata-accumulate": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/data-factory": "^2.7.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-2.8.0.tgz",
+      "integrity": "sha512-9x4nuWbvilwsapeAZS+bV4NJOSUO0qYh7HP8tEloD+UcqLOsu4KGhBkGYfx7nZC96FaManbxuuH63BCHRYI/jQ==",
+      "dependencies": {
+        "@comunica/bus-dereference-rdf": "^2.8.0",
+        "@comunica/bus-http-invalidate": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-metadata": "^2.8.0",
+        "@comunica/bus-rdf-metadata-accumulate": "^2.8.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "@types/lru-cache": "^7.0.0",
+        "asynciterator": "^3.8.0",
+        "lru-cache": "^10.0.0",
+        "rdf-streaming-store": "^1.1.0",
+        "readable-stream": "^4.2.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/node_modules/lru-cache": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-2.8.0.tgz",
+      "integrity": "sha512-UqijQFYcUfxekgU37lhUtcTftVHDTBJwBIBTGJS7rZF/2ti45bwOK3ogN+1Wtkfb1r07Ti87ZJhZE5hExRaEmA==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-terms": "^1.11.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-string-source": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-string-source/-/actor-rdf-resolve-quad-pattern-string-source-2.8.0.tgz",
+      "integrity": "sha512-H3NSj1iXGlWPCua1wMTYMsUcjafn+Y2+hOAPnaCDaN2ctcqoStPct7yg/DZv/dqSlqq1Xwb5hcyVu+Afw5XRRw==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "lru-cache": "^10.0.0",
+        "rdf-store-stream": "^2.0.0",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-string-source/node_modules/lru-cache": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-string-source/node_modules/rdf-store-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-2.0.0.tgz",
+      "integrity": "sha512-FKRsA5XUdhFVMx+jg4JCBM76B4ZcXVKyilr8GJrlfkHB2IZSIgLxY2XHIsewkDfm/yAtXHvPT0PaeQg4Mbqa6g==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-stores": "^1.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-jsonld": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.8.0.tgz",
+      "integrity": "sha512-qmmt/WWlMFzrHIAghGSrq2wtNwQ8FUHJZw+l/PGJ2f0GbasDJECPWieYPJweHztOOTZ962hsjpjaiaDGMbGV8A==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "jsonld-streaming-serializer": "^2.1.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-n3": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.8.0.tgz",
+      "integrity": "sha512-u6fRZI4K8w+kFqM4jvOe0egVHWavJQ15mk/+0ddLNWem21ETSXY5wkeEauFBKUj21/Buzr8wzp0d8RuG/+L2BQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "n3": "^1.17.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-shaclc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-2.8.0.tgz",
+      "integrity": "sha512-SOoYVxjuf0sCv8MRli8mpgvawJW4dd5CymPgcOE9hh8HcRluMwgCYAUB96B9+4g1MwCirc2LuR9LNqhKZGnFhA==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "arrayify-stream": "^2.0.1",
+        "readable-stream": "^4.3.0",
+        "shaclc-write": "^1.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-2.8.0.tgz",
+      "integrity": "sha512-yvMk66avpqtuEHl9fvz/HUWvN/f4GHcXLCsrH4WZxUsaLnFBfgO1jTRgAWmqGUG3afPcWhEwLaR2wQszLKslZw==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "cross-fetch": "^3.1.5",
+        "rdf-string-ttl": "^1.3.2",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-put-ldp": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-2.8.0.tgz",
+      "integrity": "sha512-dxc769C15b7sVQ+7gFfrcVCLbnYTBh06gU+sU6QO2SPciVRBCk4J+W5BRGN6vED87FZWmQHdmvgpfhoFmuhz1g==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-rdf-serialize": "^2.8.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-sparql": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-2.8.0.tgz",
+      "integrity": "sha512-RxVXrwyfsdJyEXGMdLg1ZunGgdu3HvSkiYazVzHwjTgSoWQ8J1M6sVe8ApMJIBJoK03KLoFupvnHmVF5sh+PQQ==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "fetch-sparql-endpoint": "^3.3.2",
+        "rdf-string-ttl": "^1.3.2",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-hypermedia": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-2.8.0.tgz",
+      "integrity": "sha512-D9q7GyR7p182nuPGnijJVyZCJkkE9tTxicUgK58k6t88t11qbfjxe6RXz0SabmwjEshX+6/mHkQy9MQFC6YhBQ==",
+      "dependencies": {
+        "@comunica/bus-dereference-rdf": "^2.8.0",
+        "@comunica/bus-http-invalidate": "^2.8.0",
+        "@comunica/bus-rdf-metadata": "^2.8.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@types/lru-cache": "^7.0.0",
+        "lru-cache": "^10.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-hypermedia/node_modules/lru-cache": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-2.8.0.tgz",
+      "integrity": "sha512-TJICnRea5PQvgQXwN0r4k9IHjSveHE12Xziqwwsn0Y5iECoplCE/yJdpq1JyVQam+3nlSm/dvmdOa8ySR54n2A==",
+      "dependencies": {
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/bindings-factory": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bindings-factory/-/bindings-factory-2.7.0.tgz",
+      "integrity": "sha512-NeLbBmqiNhyUCZSfqZfwZD50dQ5+DABgPbzfuZnbHq9uSfhxAzuGCzgrK0hmuwRHWOPBtmeRnyZTJorePuxTzQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "immutable": "^4.1.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/bus-context-preprocess": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-2.8.0.tgz",
+      "integrity": "sha512-73J9mTEQAnbOV36JPP7F72iLWkSXwM5QWF0Xxtp4RwtbK54z2wBqNjvT9+FFUBzp3qFSuXzN9zhSx4+XlxIYdQ==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/bus-dereference": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-2.8.0.tgz",
+      "integrity": "sha512-iCB3juIib4BfhzRkH/Or728dd2ClsamwsWLKQ++rhcy9fw0asy5xSrLGolZyvT+ZwiXomLOoI7Cnr1vhy4pNCQ==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.8.0",
+        "@comunica/actor-abstract-parse": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-dereference-rdf": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.8.0.tgz",
+      "integrity": "sha512-VFRSlr8ZLAagpBmKIuqhdVGrdo0cj4wFtROMLlMggudgIQw+Epl71UgOPjuRreAcs//tsYm0tscVQ5Zvshlm0Q==",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.8.0",
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-hash-bindings": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-2.8.0.tgz",
+      "integrity": "sha512-zK3yoINSkQ+aF2g+JcKq/Fh7wDtnTB58Tbr/V9E4RgXu2WgZR2gQBMXEi8IxQuAuFgresxx9Ku87W1opu/btsg==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/bus-http": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.8.0.tgz",
+      "integrity": "sha512-xwH0Ep0JertuG2Xn/+lw3CgGtphPgwWuJj3p1/Ri34ORZmusrqv51/BNU63iRyr2QG4XT275V8Sj0RiHy8/PPg==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
         "is-stream": "^2.0.1",
         "readable-stream-node-to-web": "^1.0.1",
         "readable-web-to-node-stream": "^3.0.2",
         "web-streams-ponyfill": "^1.4.2"
       }
     },
-    "node_modules/@comunica/actor-http-fetch/node_modules/@comunica/context-entries": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.5.1.tgz",
-      "integrity": "sha512-TnF476Nv9+DfZ+JLTQU7OSqmFREScVkpBtU71seT6He+vkJBHDm6Nq4tnKwDmAI3v9dCc5dgCRU4F2uPDjBKZA==",
+    "node_modules/@comunica/bus-http-invalidate": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-2.8.0.tgz",
+      "integrity": "sha512-As5ZIB1yEf4LFhQgsWxQDWceNMMm6dWcbs8cjj3I0AJ5FW+oOmHAD9cn4pXdghO7rKdJ36CtNP/hA9hqhOYJFw==",
       "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1",
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.2.2",
-        "sparqlalgebrajs": "^4.0.5"
+        "@comunica/core": "^2.8.0"
       }
     },
-    "node_modules/@comunica/actor-http-fetch/node_modules/@comunica/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
+    "node_modules/@comunica/bus-init": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.8.0.tgz",
+      "integrity": "sha512-vJaxW7plwuQXuifLfIPWjzdx2QX7goBBD+xsQOVEcJxytkQBzcRkyZMzoY/ZYjtBBvZkdgK+ks1oHupsGeUe2Q==",
       "dependencies": {
-        "@comunica/types": "^2.5.1",
+        "@comunica/core": "^2.8.0",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-optimize-query-operation": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-2.8.0.tgz",
+      "integrity": "sha512-RBNxnvsjsJnBOOPbOmZrKX8saAq6uAlIwF32+bJTWgNVDht2SEZXMLOnTazkEZIdXQ49Ih9j9OXG7pjAwmLRsA==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-operation": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-2.8.0.tgz",
+      "integrity": "sha512-019WntrY64Mz7DMdhvO3TD22F6Jf3Cc89gLcbg2nQFcosee01wLRW1CT/WsZbU/uIyfwGtg6wbZjUZHG9jIRdQ==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/data-factory": "^2.7.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-string": "^1.6.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-parse": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-2.8.0.tgz",
+      "integrity": "sha512-mRjR8DUYkWPjYqWXLytLHYr/jlgvPEtbCezo6/b4hX3pfdB2j65kzjeSYzc60QqNG3U9PKix4Y1lH7PHteiKOA==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-result-serialize": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-2.8.0.tgz",
+      "integrity": "sha512-4vNL6gRjS2GXiTfspA7VSTkquiI6w0O0BllNRjk7EkuTeX87eizG2jIgeJ+TZxaYg5Xkysh2gexWsa090GRCSw==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-2.8.0.tgz",
+      "integrity": "sha512-bGc19rDb9CylWrEepvdwZx3HtQWwsDVsbTjp3SJyWNcmTLPWKG+3Slha1v4soPSlJEPVF/VZCxnsZ9oDquBrZA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join-selectivity": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join-entries-sort": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-2.8.0.tgz",
+      "integrity": "sha512-D16zfasaw3H0buY2RzNlO6PM6DGqHjtiXywgJkhK1a+VVNoPvLBaClSCJPr6uDR1R3g3jIRfwsjjxsyAOnTmhA==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join-selectivity": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-2.8.0.tgz",
+      "integrity": "sha512-EIMwT8mYG/Hpw9LB5Vrt+Sx06hcWl4CklGVPWhjHKB/I7dfdLeEANdIPP8X5zDxtTAU8Mp+5mjwF8Kg46rxsDQ==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/mediatortype-accuracy": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-2.8.0.tgz",
+      "integrity": "sha512-a9j48dIh0J40nFPlEs2rNoZwpUwvDfmC/qVYLPgzJB+WoJ9+A3qXuIIqJLk4/cBhpopjqNC1uaUoLHYz7bmzdQ==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata-accumulate": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-2.8.0.tgz",
+      "integrity": "sha512-90/KIDfgsD5hrs3tZCCOHoXsh6YxeG2WEzjbtSrCB5+/qZgI6+nYWAnqXVrgmAZxELv0ah7VJ/4cNq9WpFQ6FA==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata-extract": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-2.8.0.tgz",
+      "integrity": "sha512-mluv6pA+mpzf036ykvXZ9TNNzK1eYg0mVKte4mHDTzQAT+XUGNcKRxO00sZQ1APO0HhQqhgK2v3DfPapmFwYgg==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.8.0.tgz",
+      "integrity": "sha512-ksCDIaO9egUQjfPK/GprTZAPBn58IhEpG4f38V3BoB2XwddZsVMpiyBhRECROy+E0VfpixY/5o6j1zjOeEtOkA==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.8.0",
+        "@comunica/actor-abstract-parse": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.8.0.tgz",
+      "integrity": "sha512-KdQa+mN91XOnmYrXIEff0uoac9krpHTrh9evDMhV/mPDWU9a6dsd+1ZyKVmMi4HMN1t3ouYdDk0+4YYTkJhO+g==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-2.8.0.tgz",
+      "integrity": "sha512-9HXCqFH8hGsRYHwhHu5vSsytPBfaHYWrWIufI6TnqNEOgQspesx4Uj1kj3yhCz5dTDFRxqzLjJT4zWmyeAl/PA==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-2.8.0.tgz",
+      "integrity": "sha512-7fNME9hAzCCSrHXdThZCb/twLLYLko+HA/ODv24yVTuYHyeuBiVC5IIq+8y10ulq6bSqdZdqzf2EfjemzUCgNA==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links-queue": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-2.8.0.tgz",
+      "integrity": "sha512-f41p4ksEF2MK6NlZBepGTpA5C5jmjx89ao40/xGXSBSASgAiyFyfChDGbrNjQSTFdJlQjs76Re5iEDNAG9+BaQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-quad-pattern": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-2.8.0.tgz",
+      "integrity": "sha512-O+ZcrtGi0tQoaOhW51JquqFrtN3Ko5xKm3nBg6TIgWphn4+jeStf64dwUkdKpVYVNe3A/iwI+c6pggUSBKWWjA==",
+      "dependencies": {
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-serialize": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.8.0.tgz",
+      "integrity": "sha512-Bi473F0l66MQz8PkTDLIPErLVUn/Hku05MCVkCpGb30O/EfqolP6W19XlP1fctFVAULSXVR8eXx1tuZImle9Nw==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-update-hypermedia": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-2.8.0.tgz",
+      "integrity": "sha512-C38CBM5jO63LNBxMFWduLcflt88t4fiMgs6AMNEuEN487znLWwVDwa7Rv9s21uClvPrXm8Zn75HNJNp4IO8oyg==",
+      "dependencies": {
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-update-quads": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-2.8.0.tgz",
+      "integrity": "sha512-G0V5UI/T5MVORyvCSubpJUsq39+HOFj3apRIRTewJQKRqnJDiWRDxIud0i4nYebDUkK8XyLkNSXE03BNtKbNGw==",
+      "dependencies": {
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^2.8.0",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/config-query-sparql": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-2.7.0.tgz",
+      "integrity": "sha512-rMnFgT7cz9+0z7wV4OzIMY5qM9/Z0mTGrR8y2JokoHyyTcBGOSajFmy61XCSLMCsLLG8qDXsJ4ClCCky3TGfqA=="
+    },
+    "node_modules/@comunica/context-entries": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.8.0.tgz",
+      "integrity": "sha512-dwTyRatuHoEkPuNGzjfB68ctKWeYD7z6RaphtraWPoE/bkU5LGWlFBa5l/H6c/thjBVsc6Ds2iBxziR6A699iA==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.2.2",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-x9U223laJ/WnPWpOyOuZ1zBygtl1UKmlySspzT+8SZrByervWIe836Xkt1JP0JNTMh54FlRa6Pg1DwYcoin5Hg==",
+      "dependencies": {
+        "@comunica/types": "^2.8.0",
         "immutable": "^4.1.0"
       },
       "engines": {
         "node": ">=14.0"
       }
     },
-    "node_modules/@comunica/actor-http-fetch/node_modules/@comunica/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
+    "node_modules/@comunica/data-factory": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-2.7.0.tgz",
+      "integrity": "sha512-dSTzrR1w9SzAWx70ZXKXHUC8f0leUolLZ9TOhGjFhhsBMJ9Pbo0g6vHV8txX5FViShngrg9QNKhsHeQnMk5z6Q==",
       "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.13",
-        "asynciterator": "^3.8.0",
-        "sparqlalgebrajs": "^4.0.5"
+        "@rdfjs/types": "*"
       }
     },
-    "node_modules/@comunica/actor-http-fetch/node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-    },
-    "node_modules/@comunica/actor-http-fetch/node_modules/sparqlalgebrajs": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-      "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
+    "node_modules/@comunica/logger-pretty": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-2.8.0.tgz",
+      "integrity": "sha512-rehoKAoH0weUEisdR4F2wyPK7DNHDKWRCa8b+UafRJRfXV10VcBSQCz6ba3wuP9u1eQujVMbBmV3lCmVAPIOGg==",
       "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.3",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.6",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.6.1"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+        "@comunica/types": "^2.8.0",
+        "object-inspect": "^1.12.2",
+        "process": "^0.11.10"
       }
     },
-    "node_modules/@comunica/actor-http-memento": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.22.1.tgz",
-      "integrity": "sha512-H10dWC+RA/xkhORKBMUIw133PxKXmo8ByEeYgbV3QplyeZ5+Wv+0hh+Icil4rC5rsqcpW+iU2TZGK6vfsTQpMQ==",
+    "node_modules/@comunica/logger-void": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-2.8.0.tgz",
+      "integrity": "sha512-l13W2cX3u+fRJ31v5ik7xurQFbP7yqTknmqAdArf9cpJ5o+AbeEZv/wBud6Ws6dq8hmcgEDtN4cECR6MmQvSAQ==",
       "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/parse-link-header": "^1.0.0",
-        "cross-fetch": "^3.0.5",
-        "parse-link-header": "^1.0.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/core": "^1.0.0"
+        "@comunica/types": "^2.8.0"
       }
     },
-    "node_modules/@comunica/actor-http-native": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.22.1.tgz",
-      "integrity": "sha512-BdB+hvQ9CJF9tI42hNhcvTMagOty+jw21LIQDJWI628xMcXZ88BJaUX0Ulc7g2nrWH97ZRm5+KjLC4Zf+OGwZg==",
+    "node_modules/@comunica/mediator-all": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-2.8.0.tgz",
+      "integrity": "sha512-kbbIKRel+l3WjIRMxQXnQwWMIdhLpb4qskKzC4INtsDyCAIBOsX3YR9dQJzvvuHq/W30ICYBen+7SLiYFR2LPg==",
       "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/parse-link-header": "^1.0.0",
-        "cross-fetch": "^3.0.5",
-        "follow-redirects": "^1.5.1",
-        "parse-link-header": "^1.0.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/core": "^1.0.0"
+        "@comunica/core": "^2.8.0"
       }
     },
-    "node_modules/@comunica/actor-http-node-fetch": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-node-fetch/-/actor-http-node-fetch-1.21.2.tgz",
-      "integrity": "sha512-6TIL5WhHd8CZasgU4EgXn9GovZ51xexshxolo4rN7xI5uzfGXemHWHVQwiPJNdBbud/Hi7nCJJNrBRtdI/b2pw==",
+    "node_modules/@comunica/mediator-combine-pipeline": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.8.0.tgz",
+      "integrity": "sha512-onXpWpTmtHPEWdXiZezelnt2sbGHrUHGnw+N8H15QlfC45nrHz6NhH7FEdc+L9q2VjgtXdlfR84x/senNAMCfw==",
       "dependencies": {
-        "@comunica/context-entries": "^1.21.1",
-        "cross-fetch": "^3.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/core": "^1.0.0"
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
       }
     },
-    "node_modules/@comunica/actor-http-proxy": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.21.1.tgz",
-      "integrity": "sha512-Z3NvOzZeffZ+aRBZVg3apbVSNjYvAUE49oOL+BrBtT5CuEf+RUOCcSOV/UhpITIFg21/uuyaxvJaT5RmfH+xzw==",
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.8.0",
-        "@comunica/context-entries": "^1.0.0",
-        "@comunica/core": "^1.8.0"
+    "node_modules/@comunica/mediator-combine-union": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.8.0.tgz",
+      "integrity": "sha512-2ZqItxIX4lb1VYBo6TFm1SfDXZ0iqZ2c3r/WlukEx3sC2/C3cTG53jvjaxb6B/0fi86fGykv7wrQKinbaE+GWQ==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0"
       }
     },
-    "node_modules/@comunica/actor-init-sparql": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.21.3.tgz",
-      "integrity": "sha512-R7auYy7gppLt0nUAc+Y+3mjYmwaLzr02PTx9XGO/ojUi/LnCuU2lrS2Fik90b9N3kg5kDJYN/znT/XHpy5vdGg==",
+    "node_modules/@comunica/mediator-join-coefficients-fixed": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-2.8.0.tgz",
+      "integrity": "sha512-Qmee8MbiQP1C1KyRJ0BuyMorH3t0DbLM7l7ccSRCTdnmRgDYn7yljJZ5QAgblgdm6gZXhYsCNXpLydGJjImtAw==",
       "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.21.1",
-        "@comunica/actor-abstract-mediatyped": "^1.21.1",
-        "@comunica/actor-context-preprocess-source-to-destination": "^1.21.1",
-        "@comunica/actor-http-memento": "^1.21.1",
-        "@comunica/actor-http-native": "^1.21.3",
-        "@comunica/actor-http-proxy": "^1.21.1",
-        "@comunica/actor-optimize-query-operation-join-bgp": "^1.21.1",
-        "@comunica/actor-query-operation-ask": "^1.21.1",
-        "@comunica/actor-query-operation-bgp-empty": "^1.21.1",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.21.2",
-        "@comunica/actor-query-operation-bgp-single": "^1.21.1",
-        "@comunica/actor-query-operation-construct": "^1.21.1",
-        "@comunica/actor-query-operation-describe-subject": "^1.21.1",
-        "@comunica/actor-query-operation-distinct-hash": "^1.21.1",
-        "@comunica/actor-query-operation-extend": "^1.21.2",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.21.2",
-        "@comunica/actor-query-operation-from-quad": "^1.21.1",
-        "@comunica/actor-query-operation-group": "^1.21.1",
-        "@comunica/actor-query-operation-join": "^1.21.1",
-        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.21.1",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.21.2",
-        "@comunica/actor-query-operation-minus": "^1.21.1",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.21.2",
-        "@comunica/actor-query-operation-path-alt": "^1.21.1",
-        "@comunica/actor-query-operation-path-inv": "^1.21.1",
-        "@comunica/actor-query-operation-path-link": "^1.21.1",
-        "@comunica/actor-query-operation-path-nps": "^1.21.1",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.21.1",
-        "@comunica/actor-query-operation-path-seq": "^1.21.1",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.21.1",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.21.1",
-        "@comunica/actor-query-operation-project": "^1.21.1",
-        "@comunica/actor-query-operation-quadpattern": "^1.21.1",
-        "@comunica/actor-query-operation-reduced-hash": "^1.21.1",
-        "@comunica/actor-query-operation-service": "^1.21.1",
-        "@comunica/actor-query-operation-slice": "^1.21.1",
-        "@comunica/actor-query-operation-sparql-endpoint": "^1.21.2",
-        "@comunica/actor-query-operation-union": "^1.21.1",
-        "@comunica/actor-query-operation-update-add-rewrite": "^1.21.1",
-        "@comunica/actor-query-operation-update-clear": "^1.21.1",
-        "@comunica/actor-query-operation-update-compositeupdate": "^1.21.1",
-        "@comunica/actor-query-operation-update-copy-rewrite": "^1.21.1",
-        "@comunica/actor-query-operation-update-create": "^1.21.1",
-        "@comunica/actor-query-operation-update-deleteinsert": "^1.21.1",
-        "@comunica/actor-query-operation-update-drop": "^1.21.1",
-        "@comunica/actor-query-operation-update-load": "^1.21.1",
-        "@comunica/actor-query-operation-update-move-rewrite": "^1.21.1",
-        "@comunica/actor-query-operation-values": "^1.21.1",
-        "@comunica/actor-rdf-dereference-fallback": "^1.21.1",
-        "@comunica/actor-rdf-dereference-http-parse": "^1.21.2",
-        "@comunica/actor-rdf-join-multi-smallest": "^1.21.1",
-        "@comunica/actor-rdf-join-nestedloop": "^1.21.1",
-        "@comunica/actor-rdf-join-symmetrichash": "^1.21.1",
-        "@comunica/actor-rdf-metadata-all": "^1.21.1",
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.21.1",
-        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.21.1",
-        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^1.21.1",
-        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.21.2",
-        "@comunica/actor-rdf-metadata-primary-topic": "^1.21.1",
-        "@comunica/actor-rdf-parse-html": "^1.21.1",
-        "@comunica/actor-rdf-parse-html-microdata": "^1.21.1",
-        "@comunica/actor-rdf-parse-html-rdfa": "^1.21.1",
-        "@comunica/actor-rdf-parse-html-script": "^1.21.1",
-        "@comunica/actor-rdf-parse-jsonld": "^1.21.2",
-        "@comunica/actor-rdf-parse-n3": "^1.21.1",
-        "@comunica/actor-rdf-parse-rdfxml": "^1.21.1",
-        "@comunica/actor-rdf-parse-xml-rdfa": "^1.21.1",
-        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.21.1",
-        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.21.1",
-        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.21.1",
-        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.21.1",
-        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.21.2",
-        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.21.1",
-        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.21.1",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.21.1",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.21.1",
-        "@comunica/actor-rdf-serialize-n3": "^1.21.1",
-        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^1.21.1",
-        "@comunica/actor-rdf-update-quads-hypermedia": "^1.21.1",
-        "@comunica/actor-rdf-update-quads-rdfjs-store": "^1.21.1",
-        "@comunica/actor-sparql-parse-algebra": "^1.21.1",
-        "@comunica/actor-sparql-parse-graphql": "^1.21.1",
-        "@comunica/actor-sparql-serialize-json": "^1.21.1",
-        "@comunica/actor-sparql-serialize-rdf": "^1.21.1",
-        "@comunica/actor-sparql-serialize-simple": "^1.21.1",
-        "@comunica/actor-sparql-serialize-sparql-csv": "^1.21.1",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.21.1",
-        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.21.1",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.21.1",
-        "@comunica/actor-sparql-serialize-stats": "^1.21.1",
-        "@comunica/actor-sparql-serialize-table": "^1.21.1",
-        "@comunica/actor-sparql-serialize-tree": "^1.21.1",
-        "@comunica/bus-context-preprocess": "^1.21.1",
-        "@comunica/bus-http": "^1.21.1",
-        "@comunica/bus-http-invalidate": "^1.21.1",
-        "@comunica/bus-init": "^1.21.1",
-        "@comunica/bus-optimize-query-operation": "^1.21.1",
-        "@comunica/bus-query-operation": "^1.21.1",
-        "@comunica/bus-rdf-dereference": "^1.21.1",
-        "@comunica/bus-rdf-dereference-paged": "^1.21.1",
-        "@comunica/bus-rdf-join": "^1.21.1",
-        "@comunica/bus-rdf-metadata": "^1.21.1",
-        "@comunica/bus-rdf-metadata-extract": "^1.21.1",
-        "@comunica/bus-rdf-parse": "^1.21.1",
-        "@comunica/bus-rdf-parse-html": "^1.21.1",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.21.1",
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.21.1",
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.21.1",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
-        "@comunica/bus-rdf-serialize": "^1.21.1",
-        "@comunica/bus-rdf-update-hypermedia": "^1.21.1",
-        "@comunica/bus-rdf-update-quads": "^1.21.1",
-        "@comunica/bus-sparql-parse": "^1.21.1",
-        "@comunica/bus-sparql-serialize": "^1.21.1",
-        "@comunica/context-entries": "^1.21.1",
-        "@comunica/core": "^1.21.1",
-        "@comunica/logger-pretty": "^1.21.1",
-        "@comunica/logger-void": "^1.21.1",
-        "@comunica/mediator-all": "^1.21.1",
-        "@comunica/mediator-combine-pipeline": "^1.21.1",
-        "@comunica/mediator-combine-union": "^1.21.1",
-        "@comunica/mediator-number": "^1.21.1",
-        "@comunica/mediator-race": "^1.21.1",
-        "@comunica/runner": "^1.21.1",
-        "@comunica/runner-cli": "^1.21.1",
-        "@types/minimist": "^1.2.0",
-        "@types/rdf-js": "*",
-        "asynciterator": "^3.1.0",
-        "minimist": "^1.2.0",
-        "negotiate": "^1.0.1",
-        "rdf-quad": "^1.4.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.5.5",
-        "streamify-string": "^1.0.1"
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/mediator-number": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.8.0.tgz",
+      "integrity": "sha512-IrdFeV2FHTwUUXfWjdP+OE9mBfqZwBm/T6jF02Vlr+NWqMFGmMoMu0W+PnAg6YznqnqonLInF4HRj8QIsidHGA==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/mediator-race": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.8.0.tgz",
+      "integrity": "sha512-cI7BCKKeo+1LgaMzBRw1s9ZINSB/N6zULEznCxQs02Im0U4NUHs0sc6KTdACI8m4iNEM960EjDOFr7CeA8275g==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-accuracy": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-2.8.0.tgz",
+      "integrity": "sha512-5WmCCpGHdwkygwxs2hLrGqQIQkeCoTHHs+bzVVgFPudvryJzatLQACBVrojAs3pk7rS+3I31BxCwmaU7QcRRsQ==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-httprequests": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-httprequests/-/mediatortype-httprequests-2.8.0.tgz",
+      "integrity": "sha512-128F3cSndJWkLktiir95uLKiFnt7QgYZ7k5slvtrRms1pbjQb5zAP7dUwoMFEGfyVis0kvYiIPn500rXeGa36w==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-join-coefficients": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-2.8.0.tgz",
+      "integrity": "sha512-5axVSMduA4ao9OiuIJi6nejEohdBOLAAJVMcOuypojhTJA5GAhQh1HEbnjLIGaUwXWQMuB7CCgHWn6hNDMo5Hw==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.8.0.tgz",
+      "integrity": "sha512-NCfn2AtX1z2rxRTQyyPkvOs1IEFUClNPOE7NaS4wg67jcWYQRKITcxf9CUT/UkMqG25MkkepMo75DiqqFmmarg==",
+      "dependencies": {
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/metadata": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/metadata/-/metadata-2.8.0.tgz",
+      "integrity": "sha512-sd0SZsmv5QBg5yon8lAXhIx1KBLfVNg0qPWR3bOSbrQqKAW0YUAGJ4o8ut2WnmquWTZIHAmDQLKwluT8pvot/g==",
+      "dependencies": {
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "node_modules/@comunica/query-sparql": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/query-sparql/-/query-sparql-2.8.0.tgz",
+      "integrity": "sha512-ynFsbxgBQzlfALd87bUdCUOTZQK4oiMS852AHHMfHdIV4ya8nTmvEot4oXpjO46dggIbTZsUiSDA68MG7RajPQ==",
+      "dependencies": {
+        "@comunica/actor-context-preprocess-source-to-destination": "^2.8.0",
+        "@comunica/actor-dereference-fallback": "^2.8.0",
+        "@comunica/actor-dereference-http": "^2.8.0",
+        "@comunica/actor-dereference-rdf-parse": "^2.8.0",
+        "@comunica/actor-hash-bindings-sha1": "^2.8.0",
+        "@comunica/actor-http-fetch": "^2.8.0",
+        "@comunica/actor-http-proxy": "^2.8.0",
+        "@comunica/actor-http-wayback": "^2.8.0",
+        "@comunica/actor-init-query": "^2.8.0",
+        "@comunica/actor-optimize-query-operation-bgp-to-join": "^2.8.0",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^2.8.0",
+        "@comunica/actor-optimize-query-operation-join-connected": "^2.8.0",
+        "@comunica/actor-query-operation-ask": "^2.8.0",
+        "@comunica/actor-query-operation-bgp-join": "^2.8.0",
+        "@comunica/actor-query-operation-construct": "^2.8.0",
+        "@comunica/actor-query-operation-describe-subject": "^2.8.0",
+        "@comunica/actor-query-operation-distinct-hash": "^2.8.0",
+        "@comunica/actor-query-operation-extend": "^2.8.0",
+        "@comunica/actor-query-operation-filter-sparqlee": "^2.8.0",
+        "@comunica/actor-query-operation-from-quad": "^2.8.0",
+        "@comunica/actor-query-operation-group": "^2.8.0",
+        "@comunica/actor-query-operation-join": "^2.8.0",
+        "@comunica/actor-query-operation-leftjoin": "^2.8.0",
+        "@comunica/actor-query-operation-minus": "^2.8.0",
+        "@comunica/actor-query-operation-nop": "^2.8.0",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^2.8.0",
+        "@comunica/actor-query-operation-path-alt": "^2.8.0",
+        "@comunica/actor-query-operation-path-inv": "^2.8.0",
+        "@comunica/actor-query-operation-path-link": "^2.8.0",
+        "@comunica/actor-query-operation-path-nps": "^2.8.0",
+        "@comunica/actor-query-operation-path-one-or-more": "^2.8.0",
+        "@comunica/actor-query-operation-path-seq": "^2.8.0",
+        "@comunica/actor-query-operation-path-zero-or-more": "^2.8.0",
+        "@comunica/actor-query-operation-path-zero-or-one": "^2.8.0",
+        "@comunica/actor-query-operation-project": "^2.8.0",
+        "@comunica/actor-query-operation-quadpattern": "^2.8.0",
+        "@comunica/actor-query-operation-reduced-hash": "^2.8.0",
+        "@comunica/actor-query-operation-service": "^2.8.0",
+        "@comunica/actor-query-operation-slice": "^2.8.0",
+        "@comunica/actor-query-operation-sparql-endpoint": "^2.8.0",
+        "@comunica/actor-query-operation-union": "^2.8.0",
+        "@comunica/actor-query-operation-update-add-rewrite": "^2.8.0",
+        "@comunica/actor-query-operation-update-clear": "^2.8.0",
+        "@comunica/actor-query-operation-update-compositeupdate": "^2.8.0",
+        "@comunica/actor-query-operation-update-copy-rewrite": "^2.8.0",
+        "@comunica/actor-query-operation-update-create": "^2.8.0",
+        "@comunica/actor-query-operation-update-deleteinsert": "^2.8.0",
+        "@comunica/actor-query-operation-update-drop": "^2.8.0",
+        "@comunica/actor-query-operation-update-load": "^2.8.0",
+        "@comunica/actor-query-operation-update-move-rewrite": "^2.8.0",
+        "@comunica/actor-query-operation-values": "^2.8.0",
+        "@comunica/actor-query-parse-graphql": "^2.8.0",
+        "@comunica/actor-query-parse-sparql": "^2.8.0",
+        "@comunica/actor-query-result-serialize-json": "^2.8.0",
+        "@comunica/actor-query-result-serialize-rdf": "^2.8.0",
+        "@comunica/actor-query-result-serialize-simple": "^2.8.0",
+        "@comunica/actor-query-result-serialize-sparql-csv": "^2.8.0",
+        "@comunica/actor-query-result-serialize-sparql-json": "^2.8.0",
+        "@comunica/actor-query-result-serialize-sparql-tsv": "^2.8.0",
+        "@comunica/actor-query-result-serialize-sparql-xml": "^2.8.0",
+        "@comunica/actor-query-result-serialize-stats": "^2.8.0",
+        "@comunica/actor-query-result-serialize-table": "^2.8.0",
+        "@comunica/actor-query-result-serialize-tree": "^2.8.0",
+        "@comunica/actor-rdf-join-entries-sort-cardinality": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-hash": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-multi-bind": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-multi-empty": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-multi-smallest": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-nestedloop": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-none": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-single": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-symmetrichash": "^2.8.0",
+        "@comunica/actor-rdf-join-minus-hash": "^2.8.0",
+        "@comunica/actor-rdf-join-minus-hash-undef": "^2.8.0",
+        "@comunica/actor-rdf-join-optional-bind": "^2.8.0",
+        "@comunica/actor-rdf-join-optional-nestedloop": "^2.8.0",
+        "@comunica/actor-rdf-join-selectivity-variable-counting": "^2.8.0",
+        "@comunica/actor-rdf-metadata-accumulate-cancontainundefs": "^2.8.0",
+        "@comunica/actor-rdf-metadata-accumulate-cardinality": "^2.8.0",
+        "@comunica/actor-rdf-metadata-accumulate-pagesize": "^2.8.0",
+        "@comunica/actor-rdf-metadata-accumulate-requesttime": "^2.8.0",
+        "@comunica/actor-rdf-metadata-all": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-allow-http-methods": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-pagesize": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-put-accepted": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-request-time": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^2.8.0",
+        "@comunica/actor-rdf-metadata-primary-topic": "^2.8.0",
+        "@comunica/actor-rdf-parse-html": "^2.8.0",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.8.0",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.8.0",
+        "@comunica/actor-rdf-parse-html-script": "^2.8.0",
+        "@comunica/actor-rdf-parse-jsonld": "^2.8.0",
+        "@comunica/actor-rdf-parse-n3": "^2.8.0",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.8.0",
+        "@comunica/actor-rdf-parse-shaclc": "^2.8.0",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.8.0",
+        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^2.8.0",
+        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^2.8.0",
+        "@comunica/actor-rdf-resolve-hypermedia-none": "^2.8.0",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^2.8.0",
+        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^2.8.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^2.8.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^2.8.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.8.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-string-source": "^2.8.0",
+        "@comunica/actor-rdf-serialize-jsonld": "^2.8.0",
+        "@comunica/actor-rdf-serialize-n3": "^2.8.0",
+        "@comunica/actor-rdf-serialize-shaclc": "^2.8.0",
+        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^2.8.0",
+        "@comunica/actor-rdf-update-hypermedia-put-ldp": "^2.8.0",
+        "@comunica/actor-rdf-update-hypermedia-sparql": "^2.8.0",
+        "@comunica/actor-rdf-update-quads-hypermedia": "^2.8.0",
+        "@comunica/actor-rdf-update-quads-rdfjs-store": "^2.8.0",
+        "@comunica/bus-http-invalidate": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/config-query-sparql": "^2.7.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/logger-void": "^2.8.0",
+        "@comunica/mediator-all": "^2.8.0",
+        "@comunica/mediator-combine-pipeline": "^2.8.0",
+        "@comunica/mediator-combine-union": "^2.8.0",
+        "@comunica/mediator-join-coefficients-fixed": "^2.8.0",
+        "@comunica/mediator-number": "^2.8.0",
+        "@comunica/mediator-race": "^2.8.0",
+        "@comunica/runner": "^2.8.0",
+        "@comunica/runner-cli": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "process": "^0.11.10"
       },
       "bin": {
         "comunica-dynamic-sparql": "bin/query-dynamic.js",
@@ -730,2793 +2218,43 @@
         "comunica-sparql-http": "bin/http.js"
       }
     },
-    "node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.22.0.tgz",
-      "integrity": "sha512-G0JSVM0q2kJb4X6p/zTyuMi4E5vdQsrJjx6Zy9FIG2EySAP+Q/M8TNSteJbyan07xZwxane6bZcCckvNyDVqTg==",
-      "dependencies": {
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-optimize-query-operation": "^1.0.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-optimize-query-operation-join-bgp/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-ask": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.22.0.tgz",
-      "integrity": "sha512-kdByALpa1SM0PFlHarDQc6KjGXZ1xaTwvmhdldov7XN6KmXZyozic0qx29d5kNgMUsDOfaTbxPZFNmBRr32K0w==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-ask/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-bgp-empty": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.22.0.tgz",
-      "integrity": "sha512-qitWhNrmehzvnNHZ98QuClOATyNRYte98OtR/C3trljMWjOrnC8pnstUHS5BN3bOBftRCBjO6ukJcnfgZFeNTQ==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-bgp-empty/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-bgp-left-deep-smallest": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.22.0.tgz",
-      "integrity": "sha512-c6u9knbOLh7W4JNGZh0Vc2dMCsDzm5/tjhhKttbvLuN8bGqvdx2Pxuv0beTyWSXhLXxeo6DkhtWAh/b+gtNBRw==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-bgp-left-deep-smallest/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-bgp-single": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.22.0.tgz",
-      "integrity": "sha512-wxOO1Df9oRiAHUgZWx+o7zP+PZF/7kkHCueBWnvFA9Qqlw3naJLoFuAnhxSh1Ej4p5XGldjd1Bt/7VUFgfKOvQ==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-bgp-single/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-construct": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.22.0.tgz",
-      "integrity": "sha512-URXw1bip+ZmBfcN6lksOMKfTOO7OuBZhJc09s6EiyBTfHbBxPmLEhkv/d/hzNiEf2D+LYHjmqRHq6gSh93g//g==",
-      "dependencies": {
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-construct/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-describe-subject": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.22.0.tgz",
-      "integrity": "sha512-DrBhicGLF00VYv6+QJ04tmKAn6nGQ0Yyih01K++yNfXByBL++1iXFrYwoLwQAJQZJ6H5FRLhYGMaB12mLq/wvQ==",
-      "dependencies": {
-        "@comunica/actor-query-operation-union": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-describe-subject/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-distinct-hash": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.22.0.tgz",
-      "integrity": "sha512-6anXCszrUDoBZdOhLBmsBFxQR/P5tPsuzGFuXP+pf7zI9zIU6nfaMeffOj+GDPClReyXf1UmyJXsIKo7r5WWUg==",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-distinct-hash/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-extend": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.22.0.tgz",
-      "integrity": "sha512-61AOM+62/Xtfd+5XtWiJUlcmK5oKQ2z77s5we2Z9AIrsxqKM90RdU9/t7U1g/3SrMiCMPNrN6mPfYiz7yG9pfA==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.2",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.4.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-extend/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-filter-sparqlee": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.22.0.tgz",
-      "integrity": "sha512-FceqE7qlPUADr3lbUbVKFL245IPNGS2OwFPIN6ksGPe1y/Cgd7f/lLpqmURxzpPELm76VgJQM5VzMOeDuwlt9Q==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.4.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-filter-sparqlee/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-from-quad": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.22.0.tgz",
-      "integrity": "sha512-rkVS/YMOb50F7vo45jgvyErbiG17DDj0pSaaMo1Dm1XWohXOvXOMoJtE+x0iTISEbw8F+g/oPjUhns3VOR38hw==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-from-quad/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-group": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.22.0.tgz",
-      "integrity": "sha512-EQCV/eFMTcplqwxcX0uR+cyaExrW0xIJPRJZkJpLX1mKYoeYh43FwYj6HQy00gwXImYYqFXw03lU0x+9P3dGLA==",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.6.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-group/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-join": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.22.0.tgz",
-      "integrity": "sha512-QJBU4Vm438SGxqpV8g+vDg7IsETCfoHsl6GaZdFb8qT8EfSeIqd/oYAKJJMH/a6SzV5f8zRwDtXeWmDcA3fS1w==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/bus-rdf-join": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-join/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-leftjoin-left-deep": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.22.0.tgz",
-      "integrity": "sha512-JetWHipImYLXffNVmSk0Q2f0CJYmO4UWjb1rixNtih2Plu10BWpwLICNhw6bnuco5LJb3/EdEmDBrWrkztXH6Q==",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.9.3",
-        "@comunica/core": "^1.9.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-leftjoin-left-deep/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-leftjoin-nestedloop": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.22.0.tgz",
-      "integrity": "sha512-NttPFDGr9vWJh5iYNz/xhLPTo7TEFc45D2UqAVa0bF2XyHSM0T+oVXKEZre+FqSxTxSxHUQ22vUXY9vctnO4Xg==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/bus-rdf-join": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-leftjoin-nestedloop/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-minus": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.22.0.tgz",
-      "integrity": "sha512-53f6V6XdypGu0aaFMHr6TcE1hOqoDHphNfd1OE/CRDbNfbK+ELz2pWTnGoWf6zGRW4srnCGA3Q5vtZpSNpOMHQ==",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-minus/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-orderby-sparqlee": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.22.0.tgz",
-      "integrity": "sha512-5R4li6DxPvSrsr5oGi8hACmSBtARD/W6EzUhEiN7IRF1UjBMGMttKo/BrlcBKsolirWrPmvNsz9Y9eLSgcxx9Q==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-orderby-sparqlee/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-alt": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.22.0.tgz",
-      "integrity": "sha512-mEDuira41HEcDdjCXcE9ofkDRD+mBOAKMKR6yl/C/xZdeC2ol/XltqbP7nZdxafgQ7rPCVAbsf0dyC2rU6uSNg==",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-alt/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-inv": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.22.0.tgz",
-      "integrity": "sha512-ZJnURpQ5JaxRR6Neh/Uea+bEVaeKFZCvVjMFxcPPelP/Xj7Bu7qSklhwwUCjgwvJafDYpdgvPNll9qV8QiQ8QA==",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-link": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.22.0.tgz",
-      "integrity": "sha512-xVqbgx8iF4YKgD4wf3CHBiTaOK+uj3IZsr/pB2xMUYL263tZCmRNF8xY9+pqnogb+7bOp2tvAn1lRXl7sydGrg==",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-link/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-nps": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.22.0.tgz",
-      "integrity": "sha512-aBM44q3wjFz7J9nuPVEI0kpsFXcN14LK1bih8SwiUz8DMb+Ls4pODgWN00Y4PZgB6Aqf3NL9bRr/8UlheQZ56A==",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-nps/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-one-or-more": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.22.0.tgz",
-      "integrity": "sha512-lc8Qp9HhMwmhLI+PFpchmExFtivbDDR8EhFUsFt0LZuSLvmz4nH1wxrOLnL99/054RIisNyz7pYa+CzAsE5KUg==",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-one-or-more/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-seq": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.22.0.tgz",
-      "integrity": "sha512-9oLdRJr9kDab0wzg75Ki54CxLkeU2lYMNGpPCj5AAtFXlXwCL3qiVnkNBjGdgyLLwg8hd6cQeOG12SYEcSfFDQ==",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-seq/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.22.0.tgz",
-      "integrity": "sha512-u9+v07ZxadcYiKTkrXW1GMiBAuS0Bi7N5Z1iPQSgD0HHC8p2JsNySteY4U9eSO5Y4lht8koeSGanplmCZY/YhA==",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-zero-or-more/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.22.0.tgz",
-      "integrity": "sha512-RnjN9y6oat2kZtYvcxBdyY29oDrO2ZH6sTwEDX4qro10QkfHm5Pa4SPGSoIdj5x1g5meeOOXisqKoZHQZUTJfA==",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-zero-or-one/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-project": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.22.0.tgz",
-      "integrity": "sha512-qjvpx4rto/CK/xefDn3232R0Ilc4DrhK5xl8RK7/l5Yn1/yFgWnqHK2sY+51O2/qeOkqYrb9ojoT9PwXHaLyXA==",
-      "dependencies": {
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-project/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-quadpattern": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.22.0.tgz",
-      "integrity": "sha512-kNNPhM28JCiJ/iYpobM+wv6Y71Q3adWTlt2GM1MF8ckU9Fa+IwdlFaZ9oYaLudLpPW48QtAXDLZgiNtZEhPNAg==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-quadpattern/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-reduced-hash": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.22.0.tgz",
-      "integrity": "sha512-vymsRgS+c4J48uzyvSIb/Qj1sJ1DEqRZXuQuw8KhCCzWmCRA49DPpx2lg2sc6PJJTjyQAU3xbqHVaZUyX5e9jQ==",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@types/lru-cache": "^5.1.0",
-        "lru-cache": "^6.0.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.2.0",
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-reduced-hash/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-service": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.22.3.tgz",
-      "integrity": "sha512-z+UUJjgYppnZwV+Oz3ZVQBZpLxUAFrAtvpuVSUmjJn6ab76X29ZQY13czY2y6TfiBhbbsW+HL5kuv0g3SEOHug==",
-      "dependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-service/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-slice": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.22.0.tgz",
-      "integrity": "sha512-BjanWrGY2EgH8nm5aEsYCLQIt4FZRYU9lQECdpihmVCloGX1ItzR5Rfk51tnGbXBarqm+pj6WoT+zSu0Ee4x2A==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-slice/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-sparql-endpoint": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.22.2.tgz",
-      "integrity": "sha512-y+bnQlhTUtlybstinINiayQVXro9lZfpBiVBM9zxyZOST/fwXho5alclasfFgwy04js8aIM1efx8eJD2OUwlxQ==",
-      "dependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/types": "^1.22.0",
-        "@comunica/utils-datasource": "^1.22.2",
-        "@rdfjs/types": "*",
-        "arrayify-stream": "^1.0.0",
-        "asynciterator": "^3.2.0",
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.2.0",
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-sparql-endpoint/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-union": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.22.0.tgz",
-      "integrity": "sha512-/qoweeCXg52ObfkFxjsU3nxsJBPavU6bCcDBJMLCFwd6VT9i7IKI+Y6aBH0CmCZpzBgaZQ1o3kGHJdUoxr+qyQ==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-union/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-add-rewrite": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-1.22.0.tgz",
-      "integrity": "sha512-4SBqqrsZBAwPJYoVr4w24D9NsAR48fQOUH6ZD05vyWG/vqedO2T2POFFNXBCCXiigr35QWvQLvbzoqamC5mbpg==",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-add-rewrite/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-clear": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-1.22.0.tgz",
-      "integrity": "sha512-qRrUrkQJjvLv6PysbVJ1vOndHIvCHXpp5CmP1GFU4SF7s0LT65PSWh6+LgmcLKs+bntVMbdqaBu58lR5jk7J7Q==",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-compositeupdate": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-1.22.0.tgz",
-      "integrity": "sha512-rDt7JtQXOQ1LZY+xuhao6pv25zrXNH6VB8I6TlOAYm6OIE+PtAtbRp5AWzg8Yjqz81UHiXGQHV8SNx51LBkmtA==",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-copy-rewrite": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-1.22.0.tgz",
-      "integrity": "sha512-WYapkqUcVZ8KWfSUlEz8iBg+OoRnHI3XvAlx6cyql4Fs/3l0Gqwc2PzWHi3N5J2AUsyiFJ28JrGDba8f1PYGLg==",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-copy-rewrite/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-create": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-1.22.0.tgz",
-      "integrity": "sha512-tZxqO+4n7qbDVJcp0VNYKRbI9uS8xTyK5s63sD53YeFl6Fl52dJtBb916R9Wb0pe2Pb37ErXF38/Z127P9EiNA==",
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-deleteinsert": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-1.22.2.tgz",
-      "integrity": "sha512-8VGwvEEjHoEVwTJXGW4USHLS5DKc5iZwn1NByTAg8YdgX8ycE2odJi766cR8GLkeZu6621OUyZIgSnLdSAuMvA==",
-      "dependencies": {
-        "@comunica/actor-query-operation-construct": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/bus-rdf-update-quads": "^1.0.0",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-drop": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-1.22.0.tgz",
-      "integrity": "sha512-5DuDEmUrUO5vktgiDIHtBJtv0k1mHQqCQyF4nKLctq2bTDPaaYK533jqPM+ucxXINryx6t4SowUgdVRqpn4VIA==",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-load": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-1.22.0.tgz",
-      "integrity": "sha512-nI4fMNGUevmprlTBgbuovJMQl+1LabCajvjC9ri5hZ9Ya0fEVQsFNbXH7H2oYlC0OOzM6uUjTdb9I8D/OzF8+g==",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-load/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-move-rewrite": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-1.22.0.tgz",
-      "integrity": "sha512-ulo9KDuUy7555C0aOdgMUgOvCTLszJy8zLzN67HKktu1wK6WKV10zVMX/OcecdFE4fIVf/AA4SKXJCgsHGpXsQ==",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-move-rewrite/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-values": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.22.0.tgz",
-      "integrity": "sha512-P6znlDSYd6aD6NlSepc++V5HbmnNE8O4vZ8nvNmwZAS4z/pWjkaFM6eQkZPdkz+qXaGTzWHS3ib2zUDq3CaD4w==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-values/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-dereference-fallback": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-fallback/-/actor-rdf-dereference-fallback-1.22.2.tgz",
-      "integrity": "sha512-EzvBerax4WVOxmkRuHviehUQ3VUU0CPHV+fErFB9+s5UbXHk6MU3GqzH9iehoFYzpP7Xic0VZXFd34nCTvzmtg==",
-      "peerDependencies": {
-        "@comunica/bus-rdf-dereference": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-dereference-file": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-file/-/actor-rdf-dereference-file-1.22.2.tgz",
-      "integrity": "sha512-KrjPfjdRQYVKyl7r8RiYK69HQ3f00f6RAc9BOhb0hlq/2PHtddAQ4oVNvs20PgHOKswsQsefd/HenLUhfa7+gw==",
-      "peerDependencies": {
-        "@comunica/bus-rdf-dereference": "^1.0.0",
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.21.2.tgz",
-      "integrity": "sha512-TLQLw6rKkcslHyyYFpELy+Oc9KuLZbqxiOpMUQQqfi1/yLT/8C0dvQSTl0dOtKombSn4N3aFsA0ycbjuPWi01w==",
-      "dependencies": {
-        "cross-fetch": "^3.0.5",
-        "relative-to-absolute-iri": "^1.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-dereference": "^1.0.0",
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-join-multi-smallest": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.22.0.tgz",
-      "integrity": "sha512-eoMuumFT+GB73f7H8Q8ijzchqHRY26w20lcKcsylC2bWS+ET8tFkYCODHop0uO53DMZPCrAm0C1higPB4XOw7Q==",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/mediatortype-iterations": "^1.22.0",
-        "@comunica/types": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-join": "^1.9.2",
-        "@comunica/core": "^1.9.2"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-join-nestedloop": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.22.0.tgz",
-      "integrity": "sha512-8APKCtsH6lWmadCnp8xkJqu0O8uqBZ1GfFmV3KxmE3jPx9lrMVckmKBAd3i7vcMHWRwzOvZF4YFJkJxL7JeqnQ==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asyncjoin": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-join": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-join-symmetrichash": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.22.0.tgz",
-      "integrity": "sha512-+K11crWY5N+Txb5HOP8P5/z2EN7WK8Cq1o1Go2RkUHhR0Pc4HZMoJtf6ATyJGB64y3lRpUVzKayrqSkDXlaSbQ==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asyncjoin": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-join": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-all": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.22.0.tgz",
-      "integrity": "sha512-8I7xrelM3G5nJ8SB5sh/cuIniAF0uDQ4AH8LA9z+aZQI5RvHN4kfgW6V/9NSmaEskyscy9m+nGkByEpuh+pHvQ==",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata": "^1.6.3",
-        "@comunica/core": "^1.6.3"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-controls": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.22.0.tgz",
-      "integrity": "sha512-fSYye14RuiT0H9il92G8bDUuOrRxRY1is/+C+ShAXb6npx05GDfO+p9Ew4hBCRbveU10DAdsarOTYpcP2bTZSQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/uritemplate": "^0.3.4",
-        "uritemplate": "0.3.4"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-count": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.22.0.tgz",
-      "integrity": "sha512-IM27SyFT2lRZc853m10I8YQX+nzSS5ouY4dLWyI3yzlYfI1LFOI/kDiUicgiyAoAy7UBG2c60jvFXTC6HQsdJw==",
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-1.22.2.tgz",
-      "integrity": "sha512-de9IJPIuXrvh8plhl8RndrbNcigO7hhi34bEoKwcjdX8YBK1F4BEK3mRvE0rlSjwv5vDLPjT4ejxl6bL2Da/rQ==",
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.20.0",
-        "@comunica/core": "^1.20.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-sparql-service": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.22.0.tgz",
-      "integrity": "sha512-z2w/bhFZ/iWq7KgdLqBD/8CWL7S9VZJSmczccgKmwQGRJWzJ4mHpUAdOCh7EFD/9HbsC4fXJGXZHQjZ8u6SM6g==",
-      "dependencies": {
-        "relative-to-absolute-iri": "^1.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-primary-topic": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.22.0.tgz",
-      "integrity": "sha512-+ZRSUVDqUZo5RLwOUbtIifiBn2Qgg6awMsfRlw2PeGE72BhQ1ik0tfz1l9Q7UuYnxnLoUFe2zyKEYc7GXAV34g==",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-html": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.22.0.tgz",
-      "integrity": "sha512-U9pznSpQ1POSH+ekOke3lYKO0fsUbNdv1g1nfuWz/MV3xMCF/d2f3CVBjXRSx9qwyb/2zUrOjBCJRrYkfZ6geQ==",
-      "dependencies": {
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
-        "@rdfjs/types": "*",
-        "htmlparser2": "^7.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-html-microdata": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-1.22.0.tgz",
-      "integrity": "sha512-OdB3Z7ZCtVAcsVU2Vs0ytGbiz0eYkeBwVA3k0vGVhSN3ygng5Thj+t8jxG6QWHlLvaIXfJFh0x57qY5tXkr8uQ==",
-      "dependencies": {
-        "microdata-rdf-streaming-parser": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse-html": "^1.17.0",
-        "@comunica/core": "^1.17.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-html-rdfa": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.22.0.tgz",
-      "integrity": "sha512-yVjYLpm9rbpPiqU1OE4Yioyk/YHtO6ywVMbdOPUNLeOwrtWou8vKX0Xh4UUR24Qrt8nuhE+p0kCJiZZtM1PmSQ==",
-      "dependencies": {
-        "rdfa-streaming-parser": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse-html": "^1.0.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-html-script": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.22.0.tgz",
-      "integrity": "sha512-gQSY56wkS/uftRyjQf+/dQFRpA/jZ6z2o2RgGbQc2avgKTkhaiTtPxpfO1oarLskm1sPlQOFo24ZwqUSqjOwcA==",
-      "dependencies": {
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
-        "@rdfjs/types": "*",
-        "relative-to-absolute-iri": "^1.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.4.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.21.2.tgz",
-      "integrity": "sha512-YUiYo2EJ9T1oUGgBwzzPRjXT+cd/xckWbtfYBzr7RugXeKjrVai8atnV1OsPc0u5iPZCTkiVCO9sI/Q6M7ig2w==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.21.1",
-        "@types/rdf-js": "*",
-        "jsonld-context-parser": "^2.1.2",
-        "jsonld-streaming-parser": "^2.3.2",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-n3": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.21.1.tgz",
-      "integrity": "sha512-SFx/hkY0yr/TxfVdEecVg3DY2KOWPeGfM288CjDQjogx6Sxb6JuF9JaipNX8/twKVdBefGS9b1S9EyKpcr99Zg==",
-      "dependencies": {
-        "@types/n3": "^1.4.4",
-        "n3": "^1.6.3"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-rdfxml": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.22.0.tgz",
-      "integrity": "sha512-k47WEAZ6qKEhf1eBZZeI5aVywlrUUKP3BKHw2zKJUjuWq5k+w/rp2WALCyt0Owtb37UlJbET3fTlUhXKvT+2aw==",
-      "dependencies": {
-        "rdfxml-streaming-parser": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.1.0",
-        "@comunica/core": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.22.0.tgz",
-      "integrity": "sha512-y315YcZTz7AizKf8Jl022IocAJIh3OHSlzNrRNH3zB7i/ch+WHj1VL9pjIf6y77PD4BR75EdeoQCPafpm5Gsbg==",
-      "dependencies": {
-        "rdfa-streaming-parser": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-next": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.22.0.tgz",
-      "integrity": "sha512-94t3u2B2kH8ftMtkLfo1B/v1SJkiFdEf3y351UOqrWJ71GNMQwgvzQFcSRL4QRcgaIjz4wecj8oGUN0wPs2Kdg==",
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.0.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-1.22.0.tgz",
-      "integrity": "sha512-DzQgHFDDXtawPvNbei1j6xL2yWdlSpq/vOD4K8Z+NrheKjNbPz84bJp0bhnWiOonwHMCRdxQRu+Etf33SFWFJQ==",
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.19.2",
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.0.0",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-none": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.22.0.tgz",
-      "integrity": "sha512-rPtjD7WAlXBwrWmG5vy9hGo5J9AlKaWuH7Cf3I0HFUnPRegF98UAFZyygQP4otDC3EsygJakbmApBkzjiKFRPw==",
-      "dependencies": {
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-store-stream": "^1.3.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-qpf": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.22.2.tgz",
-      "integrity": "sha512-dHR6FtLj/buvHmOT9B0FysWwIQO7L0+uqCnHQ9peShKOwpKMtl5qW9a8L63yWNlB34JgB+ZvL0/qJO7JWZZXTQ==",
-      "dependencies": {
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2"
-      },
-      "peerDependencies": {
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.0.0",
-        "@comunica/bus-rdf-metadata": "^1.0.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.0.0",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.0.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-qpf/node_modules/@comunica/bus-rdf-dereference": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.22.2.tgz",
-      "integrity": "sha512-dtLEmCzlscpe8AqEver8H+7a7UzyOXslUQ00VE+igt/+oAQvJpRBCQ3yB6XkyjAV/+ApLrbAjpCRf3Gp2NWfgg==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.22.1.tgz",
-      "integrity": "sha512-nbvGfhHKyPBygeQyxLyUyrQen7q3JrSJi92x8TrkhUoTxiEYM0bYUvYmsciqlxLhNxH7EPpMzzf1oaiZfiqlqA==",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-federated": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.22.0.tgz",
-      "integrity": "sha512-Cpt5LvusDUK/mnA2LlcuQ3hqpJp9CSDjd0c7NESWuR2uCXDAxugWVJAll0EosIAw0Lx82n0SneOBqh6pk2gPxQ==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/data-factory": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-federated/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.22.2.tgz",
-      "integrity": "sha512-eQhXoOYVpEJNkp6pYvJwaU+PmvR41VEKX9zivcBxRGagbLOaX5SG0xV+0I2YApB4HvagD/0IICVRRxXqODRUVA==",
-      "dependencies": {
-        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.22.0",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@comunica/utils-datasource": "^1.22.2",
-        "@rdfjs/types": "*",
-        "@types/lru-cache": "^5.1.0",
-        "asynciterator": "^3.2.0",
-        "lru-cache": "^6.0.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.0.0",
-        "@comunica/bus-http-invalidate": "^1.0.0",
-        "@comunica/bus-rdf-dereference": "^1.0.0",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.0.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.0.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.0.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/node_modules/@comunica/bus-rdf-metadata-extract": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.22.0.tgz",
-      "integrity": "sha512-u7YXAKh3jXbPBE1ATciwwdYjwi8BNDi6hkRYxszD+IKJeW6x62VXiw24sraR3mvJohl3a2tR9nQHWv9Khijisg==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "graphql-ld": "^1.4.0",
-        "rdf-store-stream": "^1.3.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-init-sparql": "^1.16.2",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.22.0.tgz",
-      "integrity": "sha512-iy7PQav5pytbtHfU7EjP9NTKRXEKNez7tZfoI6FwGVIreX0WrxpE100xCjhQt0kkkEb7l0R0Yn6n9cXsJc8Gcg==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-serialize-jsonld": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.22.0.tgz",
-      "integrity": "sha512-UrkVEkeY2Oobsjw0kiswtTNcJU9ePXlekFE0iyemZs7b3DLAibzQeMERTiY2lSV+NBwpGhKAR+6DkCjLjd/TOA==",
-      "dependencies": {
-        "jsonld-streaming-serializer": "^1.3.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.0.0",
-        "@comunica/bus-rdf-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-serialize-n3": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.22.0.tgz",
-      "integrity": "sha512-9LBLd+ayFn7Rb/ASt1ZrBjjsUZV9I01E7MB19mcz3pyCt1HZdQ0l8JeZ5gC18cOK5B/X1KKZsx2wP+ZpHwa/og==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/n3": "^1.4.4",
-        "n3": "^1.6.3",
-        "rdf-string": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-1.22.2.tgz",
-      "integrity": "sha512-CqaDel2GTxYcM9CVzMERaGlA6XVWbqjkAfvnufhl9suMiDw8aqnuw91sPMbTlh38MhAaLY6SVwmxqekmdtxOhg==",
-      "dependencies": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "cross-fetch": "^3.0.5",
-        "rdf-string-ttl": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.0.0",
-        "@comunica/core": "^1.0.0",
-        "@comunica/types": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-quads-hypermedia": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-1.22.2.tgz",
-      "integrity": "sha512-e6kbJTIo92ig4LxdgQTGHcXp3PjHjdWWqOpVDO6Um5S/hoYRWZLA5/KI9BAxIodyaMaYU+gfSymkVfSNPrJjmw==",
-      "dependencies": {
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.22.2",
-        "@types/lru-cache": "^5.1.0",
-        "lru-cache": "^6.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http-invalidate": "^1.20.0",
-        "@comunica/bus-rdf-update-quads": "^1.20.0",
-        "@comunica/core": "^1.20.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-quads-hypermedia/node_modules/@comunica/bus-rdf-dereference": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.22.2.tgz",
-      "integrity": "sha512-dtLEmCzlscpe8AqEver8H+7a7UzyOXslUQ00VE+igt/+oAQvJpRBCQ3yB6XkyjAV/+ApLrbAjpCRf3Gp2NWfgg==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-quads-hypermedia/node_modules/@comunica/bus-rdf-metadata-extract": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.22.0.tgz",
-      "integrity": "sha512-u7YXAKh3jXbPBE1ATciwwdYjwi8BNDi6hkRYxszD+IKJeW6x62VXiw24sraR3mvJohl3a2tR9nQHWv9Khijisg==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "graphql-ld": "^1.4.0",
-        "rdf-store-stream": "^1.3.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-init-sparql": "^1.16.2",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-quads-hypermedia/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-1.22.2.tgz",
-      "integrity": "sha512-veMjUWILDYzsvETvlGjFN14w5zNTAZlbFr7vmm6F4zuI5m5G4wnVHrdhU1cf7wp3foGVDOzp5jIC9Hl3UMKtCQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.4",
-        "rdf-string": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-update-quads": "^1.0.0",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-parse-algebra": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.22.0.tgz",
-      "integrity": "sha512-8XdAbj0zd2O+2dE/i+J/mdL6xAK8qYcQ6xFf61SmIPIQBxdSRmlqxKfIc+qdCp8/KyEEG/ePA6+nG0rb94nqfw==",
-      "dependencies": {
-        "@types/sparqljs": "^3.0.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqljs": "^3.4.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-parse-algebra/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-parse-graphql": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.22.0.tgz",
-      "integrity": "sha512-tbN2Vh1y+XwvkKP+6Pshq89Enr/aWmG9qJH7WKdu25GqJRN9yydk3NVHJBwGpesydtRKlgFN/UrYuM7FCls8MQ==",
-      "dependencies": {
-        "graphql-to-sparql": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-json": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.22.0.tgz",
-      "integrity": "sha512-DFFBGoQxvGHtE6t9/5vsIABUakFLok1l4FSx97fhQ3551+LiosWBbjFpswFwEr0AGKHJPEDH4qYe0gvVuUqq+w==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-string": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-rdf": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.22.0.tgz",
-      "integrity": "sha512-OMe31+egTtd7aSTi1bu3ufsNXjJDNPQ/5glxGCzPb0ZxC+lE4LMdGtMZ3mpfLy8mzEQCrMXGZboCyv1K7I9EAw==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-serialize": "^1.0.0",
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-simple": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.22.0.tgz",
-      "integrity": "sha512-wkoQz+xyd7FA00C0T70ochP3UOW4TrYpxBLbnqPkm7Iw8pFEn1iJ8ta12SNuju/lVtqfN+e16CFD0OlaGgCEZA==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-sparql-csv": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-csv/-/actor-sparql-serialize-sparql-csv-1.22.0.tgz",
-      "integrity": "sha512-dXlNRulCZRCtf+GamYrBsR4bAbLZvcFPZp1WsbuGhCygqitu2QLwTlSMphgOtyuOCPEeF8Y6+1yljqoTC58WMA==",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.15.0",
-        "@comunica/core": "^1.15.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-sparql-json": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.22.0.tgz",
-      "integrity": "sha512-bFQX/a/lAv4akO7/8xMM/lbr2ZZbSPb4byo4TlSDLihnOeB8sEXb8hBPHqHoN57faxUUqzBEy4zzx4cdcXHM4g==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-sparql-tsv": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-tsv/-/actor-sparql-serialize-sparql-tsv-1.22.0.tgz",
-      "integrity": "sha512-a/zZDura9tu0g6wP/Z1+/RUT1zKJICjeC5azOX6BOSTdt6N+ldNrB06tyRyIbPyAGSAK0t+tOgiUPWanjXXUng==",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-string-ttl": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.15.0",
-        "@comunica/core": "^1.15.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-sparql-xml": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.22.0.tgz",
-      "integrity": "sha512-vADmIcOg2A+d4MRRjp/nm1yxpRjCB1nJKaGlXgqmEfkRYKbxrhv0/WzByF6OqdrR3W3ZMTKwzAsNdo4+mWQVRQ==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "@types/xml": "^1.0.2",
-        "xml": "^1.0.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-stats": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.22.1.tgz",
-      "integrity": "sha512-v8OzTGRZNlh86f8C24WA3IIf8XfHQBMWJIxQsFsGeVj3jtB2ngYM7GZtr/xvcRjHooTULygcQIE4wwkW+KMlCQ==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.10.0",
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-table": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.22.0.tgz",
-      "integrity": "sha512-Vh8PGLHGNBnqtzqwdLAekQuneetmrpcXIdTaC+CSpjbGLamsXTfvzkPJCi4TgdxWnEmRcjMGo8MMyho0A+cToA==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-terms": "^1.6.2"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-tree": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.22.0.tgz",
-      "integrity": "sha512-ICC1jTz++ThLXjXVIbrPJvfibu1DL9eTlPpooX3P70n8RQyG80f1SBAxdn4M42Q1+YE8poRjJx1ZgxVoQ8Rnag==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "sparqljson-to-tree": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-context-preprocess": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.22.0.tgz",
-      "integrity": "sha512-N4Lmu8JovfhDBOuyhG/7Gaig4v+nWFYbrhCRpj5gSnbn4J8WwqNmcbwVWWi3jCgw/SGsk3QRIQaFXyS3IigydQ==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-dereference": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-2.5.1.tgz",
-      "integrity": "sha512-KQTc5ZfY6bqJSQov9QYiq2mFxuTDgnN+4mzHNcyqODrIf2UYefBV453uX+nZv9cE1hdUHP8+qJiNLjO/L1y3wA==",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^2.5.1",
-        "@comunica/actor-abstract-parse": "^2.5.1",
-        "@comunica/context-entries": "^2.5.1",
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1",
-        "readable-stream": "^4.2.0"
-      }
-    },
-    "node_modules/@comunica/bus-dereference-rdf": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.5.1.tgz",
-      "integrity": "sha512-QdATU52U4wpC2OILe0p9twbHbl9LjhyeTYblcc4FaGEjgJ/8TqiWpwIzZEnCPRdE+yOy9QNXLjna5/B7hVNHsw==",
-      "dependencies": {
-        "@comunica/bus-dereference": "^2.5.1",
-        "@comunica/bus-rdf-parse": "^2.5.1",
-        "@comunica/core": "^2.5.1",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@comunica/bus-dereference-rdf/node_modules/@comunica/actor-abstract-mediatyped": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.5.1.tgz",
-      "integrity": "sha512-Iz8j1XqXp/A7HJVDTtEtp7hV6nuNoIjjEUgiJUiBTM5OIx7sFbGfUd10VtHPSXB/3lHHcIo34BKNZkeurNo6BA==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1"
-      }
-    },
-    "node_modules/@comunica/bus-dereference-rdf/node_modules/@comunica/bus-rdf-parse": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.5.1.tgz",
-      "integrity": "sha512-BzfvedLkh1bOSa/WeUzLc/bQlcXWKhIkG/GwIOrCFtoWJOdOlapWdPvPS5U6sEW/UW454ClRWaqIA+GM0qeyzA==",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^2.5.1",
-        "@comunica/actor-abstract-parse": "^2.5.1",
-        "@comunica/core": "^2.5.1",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@comunica/bus-dereference-rdf/node_modules/@comunica/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-      "dependencies": {
-        "@comunica/types": "^2.5.1",
-        "immutable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/@comunica/bus-dereference-rdf/node_modules/@comunica/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.13",
-        "asynciterator": "^3.8.0",
-        "sparqlalgebrajs": "^4.0.5"
-      }
-    },
-    "node_modules/@comunica/bus-dereference-rdf/node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-    },
-    "node_modules/@comunica/bus-dereference-rdf/node_modules/sparqlalgebrajs": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-      "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.3",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.6",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.6.1"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/bus-dereference/node_modules/@comunica/actor-abstract-mediatyped": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.5.1.tgz",
-      "integrity": "sha512-Iz8j1XqXp/A7HJVDTtEtp7hV6nuNoIjjEUgiJUiBTM5OIx7sFbGfUd10VtHPSXB/3lHHcIo34BKNZkeurNo6BA==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1"
-      }
-    },
-    "node_modules/@comunica/bus-dereference/node_modules/@comunica/context-entries": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.5.1.tgz",
-      "integrity": "sha512-TnF476Nv9+DfZ+JLTQU7OSqmFREScVkpBtU71seT6He+vkJBHDm6Nq4tnKwDmAI3v9dCc5dgCRU4F2uPDjBKZA==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1",
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.2.2",
-        "sparqlalgebrajs": "^4.0.5"
-      }
-    },
-    "node_modules/@comunica/bus-dereference/node_modules/@comunica/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-      "dependencies": {
-        "@comunica/types": "^2.5.1",
-        "immutable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/@comunica/bus-dereference/node_modules/@comunica/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.13",
-        "asynciterator": "^3.8.0",
-        "sparqlalgebrajs": "^4.0.5"
-      }
-    },
-    "node_modules/@comunica/bus-dereference/node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-    },
-    "node_modules/@comunica/bus-dereference/node_modules/readable-stream": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-dereference/node_modules/sparqlalgebrajs": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-      "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.3",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.6",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.6.1"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/bus-http": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.21.1.tgz",
-      "integrity": "sha512-M6gi128ME+7uSnLPz4Bx3jgXhIb5/O7tODVHAtw9gt0z/9AAuYfmW9jqmcZ5Uwv3CCvJSvEc/m+dooCv35dTsA==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.21.1",
-        "is-stream": "^2.0.0",
-        "web-streams-node": "^0.4.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-http-invalidate": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.22.0.tgz",
-      "integrity": "sha512-JQnEvU9s+Q/OBUdKEbI15QPyO4d7opkGi1nGah9aMpFx7o3CuIa62SuzmDokfgHXOIVaOh2e6gWDNuFjCj9cBA==",
-      "peerDependencies": {
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/bus-init": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.21.1.tgz",
-      "integrity": "sha512-h8Gp/iJiyY8mbqhrbfLySwTXasjxmCX6kpM9RyXWqCBJzdx8Bfq6F/nYg2N+zpEJgyrn5zLdNgbBkcDetdeAmA==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-optimize-query-operation": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.22.0.tgz",
-      "integrity": "sha512-psRjzvqYdohXIM9AYRDawe0axJM8S1RfeRWsbi+f4z18axEDMq/FEBRkmbpCoZaQ2DR2a16RcUr0ItgchWHUJQ==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/bus-optimize-query-operation/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/bus-query-operation": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.22.0.tgz",
-      "integrity": "sha512-4qRytLHR+1ghNsct9+OArnXDPQt8/PGTwLsseI7ACZ0Q8Ao1Oq212nNshC5Vl90bueh20iksHfBFBogttzsTDA==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "immutable": "^3.8.2",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-query-operation/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-dereference": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.21.1.tgz",
-      "integrity": "sha512-gejQdUmWCtXzlrSIVwVBuTtijLncO88hpqZjqkNo+WKTilCT9GdXSqRw137GX6ZPsBXKf/Pztupid3oUPG+2xg==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.21.1",
-        "@types/rdf-js": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-dereference-paged": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.22.0.tgz",
-      "integrity": "sha512-UMjrL8VXP5gMcESAOqMq/yhaK6MlFRPtewcG7hpOEkCKUaR2Ss3N7caGCkBc3c2aLvCjuD3aZXiiRfR+JuzRRA==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-join": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.22.0.tgz",
-      "integrity": "sha512-kxxoOnSgMCEIhU1ToSnucT1nv6ktoPwTPr3uVt/q36873WdCnfUGgd1yAMGQfTQWQbOf9BlL2dYHmJkzPvx78A==",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-metadata": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.22.0.tgz",
-      "integrity": "sha512-d/eHq4ofHDll2c9SFQkxGFg8rwsezOQJ5vktGEaic1k57297ke4tEG4JB0MdgZCUNwLieAtEtB81qj0mqW1WaA==",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-metadata-extract": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.21.1.tgz",
-      "integrity": "sha512-Q1T54qlM3Vpev6H4Y/BuMpfz+Qi6/UcDeRo/eySovtCpJ2bWi8w/+UNdeGAZhYL9InqO9qJ2PUn+TiQ/sGIojg==",
-      "dependencies": {
-        "@comunica/types": "^1.21.1",
-        "@types/rdf-js": "*",
-        "graphql-ld": "^1.2.0",
-        "rdf-store-stream": "^1.2.0",
-        "sparqlalgebrajs": "^2.5.5",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-init-sparql": "^1.16.2",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-parse": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.21.1.tgz",
-      "integrity": "sha512-JQD9Cgml/W+PCSEX3WulwxiQOdULFxAFDipLk69/J9WZxOj6emufxStM8M9R+pavbLaLYRcBQWgO0KLhEn/Rnw==",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.21.1",
-        "@types/rdf-js": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-parse-html": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.22.0.tgz",
-      "integrity": "sha512-zqdLdF5qvru1vnzN4t9eXpJhi6khKm1ZWhUovBB9pfYnnyGRCQCPlFpcgJPrD8JfKd6nTvhgdLB5QcAbBb1I0A==",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-hypermedia": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.22.0.tgz",
-      "integrity": "sha512-stZUCKUOkt7DCwgSZdhY6tFiUEj4sbkjroJg6BfA3ATJptH7waINPn1D0ytrg0NHy1+vuU+5H1E6/Qtlczuk0g==",
-      "dependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.22.0.tgz",
-      "integrity": "sha512-w76L61DC/7PchmONzf7wYuMlN08TWN9Vr+ulse84/4+jResEYzCji5kYJV4AiAKQ868ufwuGJuskf6FJlUjqFg==",
-      "peerDependencies": {
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links-queue": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-1.22.0.tgz",
-      "integrity": "sha512-2l+AEDwEIGD19ogk3umDuV25h0xMpHCMliefK8aL3iUqw1LzY93aHx7A2BgidfdQKrWog6R+vkazTaL/duTX2w==",
-      "peerDependencies": {
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-quad-pattern": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.22.0.tgz",
-      "integrity": "sha512-Re3hM8mwqbPNuS23Uh0GvMI+ryC6gWMrC+johCWhDOX+iYqLv1bUgfrC0tZE4v7reMyYp6nuCVHa/9o+F3Fweg==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-quad-pattern/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-serialize": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.22.0.tgz",
-      "integrity": "sha512-GY07qx6IIfM2GoIa8Vm8rq+iU2d/r7T6fBX61ZJxAsNKrbhtniuaqMrdZ2CL6sYKSBxVTNeRzP2l+d55So8v2Q==",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-update-hypermedia": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-1.22.2.tgz",
-      "integrity": "sha512-pvTEAKDgpCuUcR+JK/8VbuhiL1WYBMe9nyWdHZrrVhQC6hJMKB6Gmrly3qc8JKVk8iPmpYyAT4Ea29DxEIl6HQ==",
-      "dependencies": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.20.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-update-quads": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-1.22.2.tgz",
-      "integrity": "sha512-MnczplJyAwZrfPAMfORKG+U8xdTxUbdKUcbopOk82JJvN3AjiDrbBetp3eS+Q+O+wV4Ae0kzrng+Q1aJ3zpiRA==",
-      "dependencies": {
-        "@comunica/bus-http": "^1.22.1",
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-update-quads/node_modules/@comunica/bus-http": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.22.1.tgz",
-      "integrity": "sha512-CZ0NDWZH0k0FOshuRQJzYr3Z+2ZM1vqr9ZepONuaoYDwyKaxl29xPs3hNfjSy6YawjEQP+elr/WDc3TxKIpu8g==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/readable-stream": "^2.3.11",
-        "is-stream": "^2.0.0",
-        "readable-web-to-node-stream": "^3.0.2",
-        "web-streams-node": "^0.4.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-sparql-parse": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.22.0.tgz",
-      "integrity": "sha512-3xnsbh5wfiCuFPMa2RHzzIIBkwVRUEdao4iydzlp3mTJjU5huWSyL6zvteIm/lIjW0HbWCQY5QfQ1FiAyZB6lA==",
-      "dependencies": {
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-sparql-parse/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/bus-sparql-serialize": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.22.0.tgz",
-      "integrity": "sha512-qBlhEkEwtScGLrlebu2YqWbyAR/765zNtxqQqUBfEXaf+3ahmSACpwKFMuxJh0v7VXWCQNKYTA5WfFlEz7V4Uw==",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@comunica/types": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/config-query-sparql": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-2.5.1.tgz",
-      "integrity": "sha512-Fg/PDp0BwoFcCBeVTPTDR8pgXjuuMXTLi3SJFT0GdgtwSPHlAikMHGywyOMK9I1TlZ2Fwwl/oIhZVNFY3Uz7YA=="
-    },
-    "node_modules/@comunica/context-entries": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-1.22.0.tgz",
-      "integrity": "sha512-HOYr1HdhgavxABpw8saZa9pueLAeGVVd/6cZ3FWcYnH3CvfQu6Ima06Gd00QdIAiGjQm01qQcWCxp0xURiqLKg=="
-    },
-    "node_modules/@comunica/core": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.21.1.tgz",
-      "integrity": "sha512-5lY/HkyOCorY2CtxQiKUKEOcUGjIKf/YG/txJrz84SKuy+zC91zq1Zt8qWfzNihCcWrgfmk0oZuvjbYvZGK4EA==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.21.1",
-        "@comunica/types": "^1.21.1",
-        "immutable": "^3.8.2"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/@comunica/data-factory": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-1.22.0.tgz",
-      "integrity": "sha512-t18NJMdB6n/CjhNKIfofTkAL2YClj842se8utnk2sfCis9OIdUW8EuRfR9iyFHmVFdfe2RjEeKBPd6iye5Ns3Q==",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/@comunica/logger-pretty": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.22.0.tgz",
-      "integrity": "sha512-YCCRDIvbhWAygEqADnKnbCt7jnR4AasnoukLOQKyv1JAYxEV61FqReGG2LMtCqYR4VWUAa9tr51Ov+vOH1cMBg==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/logger-void": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.22.0.tgz",
-      "integrity": "sha512-ORLVmoE47wqWZGdNKcZ8wpnEHtfcUKGhnDt5KbS/YV2qv4m/dG9eNIn6ax5FZeX2EFDSzWtlvMYNxNFhTvb7VQ==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediator-all": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.22.0.tgz",
-      "integrity": "sha512-jr+tYDDDJuVeW20yauB6GH3Xov0I9eW1y0V69hgcFgyi2xTBN1z+X7OkLjOBVFzYJnHmpr+rLvpxkZIiYcOW/w==",
-      "peerDependencies": {
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/mediator-combine-pipeline": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.22.0.tgz",
-      "integrity": "sha512-SSXOvup8vlw1tS60RICXO3N+pK+7OzpwFmw5VuIVfliIdzAklEBoMUy4BucxlyX64Pgvt6nUXvaSvY3JGf9GXw==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediator-combine-union": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.21.1.tgz",
-      "integrity": "sha512-wp2lbViVOOeNKTBRD+6sze7TKVX71T2RD324/1Syb8vOpwT3mtaDNJYFg0Mrwer/Xs54d7nA7JGZA2wC2HaXow==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediator-number": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.21.1.tgz",
-      "integrity": "sha512-OeuGx0R/mWI1uMMXM2V1vcR8J1DPhYXPR+Ncg4/qKHl7tSCQH1tlCgZu0+fovY2Qmc14f1tmw5YgnsE8lsikSQ==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediator-race": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.21.1.tgz",
-      "integrity": "sha512-SgdtF1JmqDyhZJsAOiVMPuV1qgdXqv/hbsFCxcmDQ+8q1ObmQ+0DZvdUe5Ymf2IyFaevsOHHG7hF5hJbLZmdmQ==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediatortype-iterations": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-iterations/-/mediatortype-iterations-1.22.0.tgz",
-      "integrity": "sha512-pN8aCGSh19FFu2IHjXJdCib2ewhOuW+DzQVkGTG0oD472amqQAlBVNxR38QParVP/ra70Isnbp+mfFlFLHrkYg==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediatortype-time": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.5.1.tgz",
-      "integrity": "sha512-3xaRx+MzUtKd8LXJcMOB2VwuH9FrgODStUaVbkcAwBoPLxFJzYvgtv49iF/e8X3vY1u0EYzJMQXjuA3sV5niRw==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1"
-      }
-    },
-    "node_modules/@comunica/mediatortype-time/node_modules/@comunica/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-      "dependencies": {
-        "@comunica/types": "^2.5.1",
-        "immutable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/@comunica/mediatortype-time/node_modules/@comunica/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.13",
-        "asynciterator": "^3.8.0",
-        "sparqlalgebrajs": "^4.0.5"
-      }
-    },
-    "node_modules/@comunica/mediatortype-time/node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-    },
-    "node_modules/@comunica/mediatortype-time/node_modules/sparqlalgebrajs": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-      "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.3",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.6",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.6.1"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
     "node_modules/@comunica/runner": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.21.1.tgz",
-      "integrity": "sha512-yFeHvFLGHTYXlROK6xKoWLnW0Wx0jL+NRzvB3izIXc+p34bOuua8sjmGFQzW0OU7/04S0xM8BUTG2n33s26yUw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-2.8.0.tgz",
+      "integrity": "sha512-d6Tu53/hQWTzREidxLq36JF6xbJmFzIO8k+qMtVSqLfAbGAUNxcitZU2gjpboB0ZHf6eOSDbaAxz6o8aQgdgWQ==",
       "dependencies": {
-        "componentsjs": "^4.0.6"
+        "@comunica/bus-init": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "componentsjs": "^5.3.2",
+        "process": "^0.11.10"
       },
       "bin": {
         "comunica-compile-config": "bin/compile-config"
-      },
-      "peerDependencies": {
-        "@comunica/bus-init": "^1.0.0",
-        "@comunica/core": "^1.0.0"
       }
     },
     "node_modules/@comunica/runner-cli": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.21.1.tgz",
-      "integrity": "sha512-T25yhU+2WJrP0xcYYpKiCPFSedy5Ml8/3geuPgU/FZZijma2jb9+PA1R9n9Mayr+Eqj37G6blcjgZ2cIVpo4aA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-2.8.0.tgz",
+      "integrity": "sha512-//cHQNbqL/WtvZf/foc5Oc7JQnd7uiiamfsSRmDg7xwVJpUsz3Lgc/ONej15oAjY9lw9OWDJUKpQahdrMGeN9A==",
       "dependencies": {
-        "@comunica/runner": "^1.21.1"
+        "@comunica/core": "^2.8.0",
+        "@comunica/runner": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "process": "^0.11.10"
       },
       "bin": {
         "comunica-run": "bin/run.js"
       }
     },
     "node_modules/@comunica/types": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-1.22.0.tgz",
-      "integrity": "sha512-ZQ8p+ZvMAKmdq6Hz2QwqIQ2JScwRMotiWz0iSw2zYHsYQOhVmLg7HSMzMHpWNEA5UWzO/A5A+Co/ONXMhlnx3g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.8.0.tgz",
+      "integrity": "sha512-LxVN0Qzl74uMgLqztKDDIkDngpETx++edg/PIhBdbzHjmiyZfPhfpClm+QebiBAFVZCC1kLioNklm67Ih8Io6Q==",
       "dependencies": {
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "immutable": "^3.8.2",
-        "sparqlalgebrajs": "^3.0.1"
-      }
-    },
-    "node_modules/@comunica/types/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/@comunica/utils-datasource": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.22.2.tgz",
-      "integrity": "sha512-f4md6ydlNu/0lCrcts0T+Rqwbyx68IdmCvyd8DChg/hWlVqKbrKW8RKPzYhIN7kyF/+IDqg0a0KVpoaaD1mBYw==",
-      "dependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/context-entries": "^1.22.0",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
+        "@types/yargs": "^17.0.13",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -3529,6 +2267,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -3558,459 +2306,6 @@
         "stream-to-string": "^1.2.0",
         "streamify-array": "^1.0.1",
         "web-streams-node": "^0.4.0"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/actor-abstract-mediatyped": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.5.1.tgz",
-      "integrity": "sha512-Iz8j1XqXp/A7HJVDTtEtp7hV6nuNoIjjEUgiJUiBTM5OIx7sFbGfUd10VtHPSXB/3lHHcIo34BKNZkeurNo6BA==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/actor-http-proxy": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.5.1.tgz",
-      "integrity": "sha512-VlBxLWgg0wC+xl3Ut8ZNSADHJZR472+VB8YI+MkQhU2uUvvt5eHUzaEu0QDY7K9sjEfbw+qh6plXCum1REOYhg==",
-      "dependencies": {
-        "@comunica/bus-http": "^2.5.1",
-        "@comunica/context-entries": "^2.5.1",
-        "@comunica/mediatortype-time": "^2.5.1",
-        "@comunica/types": "^2.5.1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/actor-rdf-parse-html": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.5.1.tgz",
-      "integrity": "sha512-2cbJ4YfII1Rvh7787/fA3OLn5+8mwp3qwiXQtxZEkuqRhsG635oUb4mQrKwywi3y2UzbK4i2fO2248qLK7HSgg==",
-      "dependencies": {
-        "@comunica/bus-rdf-parse": "^2.5.1",
-        "@comunica/bus-rdf-parse-html": "^2.5.1",
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1",
-        "@rdfjs/types": "*",
-        "htmlparser2": "^8.0.1",
-        "readable-stream": "^4.2.0"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/actor-rdf-parse-html-microdata": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.5.1.tgz",
-      "integrity": "sha512-hXpIwvBOjBLLM4ppEcu1wofjNRFavP33OHpK/Z5toOE1oyrLLtwJFpFxgc1zobhJibYuTskLlhkaCo4w5wVASA==",
-      "dependencies": {
-        "@comunica/bus-rdf-parse-html": "^2.5.1",
-        "@comunica/core": "^2.5.1",
-        "microdata-rdf-streaming-parser": "^2.0.1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/actor-rdf-parse-html-rdfa": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.5.1.tgz",
-      "integrity": "sha512-hGQ2cZC3glZVdyk4CbmLS5aDTCVHirDYqZ35484MsEipitp+bOJ9/Zg/oXRjs7DtqKmtgqUgw8FGn7dUgnzHPg==",
-      "dependencies": {
-        "@comunica/bus-rdf-parse-html": "^2.5.1",
-        "@comunica/core": "^2.5.1",
-        "rdfa-streaming-parser": "^2.0.1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/actor-rdf-parse-html-script": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.5.1.tgz",
-      "integrity": "sha512-GArg4XS6CHJbnkABYzVmyiWqNhmRHJdCUWWFMJeqYOPK5Smt5FRDdpDl0Pkh4mcUt0RBRTd0l9zW6AcuLK7iug==",
-      "dependencies": {
-        "@comunica/bus-rdf-parse": "^2.5.1",
-        "@comunica/bus-rdf-parse-html": "^2.5.1",
-        "@comunica/context-entries": "^2.5.1",
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1",
-        "@rdfjs/types": "*",
-        "readable-stream": "^4.2.0",
-        "relative-to-absolute-iri": "^1.0.7"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/actor-rdf-parse-jsonld": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.5.1.tgz",
-      "integrity": "sha512-zJxVAxDQY6CCJCrWHO+07f0PK2DwlSU00hJO2n5Y+7lkicmcUcgSbVxE3CEI0/8aq/8p2jUcCEs++hgIpeArlg==",
-      "dependencies": {
-        "@comunica/bus-http": "^2.5.1",
-        "@comunica/bus-rdf-parse": "^2.5.1",
-        "@comunica/context-entries": "^2.5.1",
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1",
-        "jsonld-context-parser": "^2.2.2",
-        "jsonld-streaming-parser": "^3.0.1",
-        "stream-to-string": "^1.2.0"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/actor-rdf-parse-n3": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.5.1.tgz",
-      "integrity": "sha512-N6P7r2co80RFrjurldR+DCz7ajqj7Ck2QLuZhCaZZY2n6IBsfdt9QcYcuMlhykYjt+/u6tVQEuWj/XWQy6mpYQ==",
-      "dependencies": {
-        "@comunica/bus-rdf-parse": "^2.5.1",
-        "@comunica/types": "^2.5.1",
-        "n3": "^1.16.3"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/actor-rdf-parse-rdfxml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.5.1.tgz",
-      "integrity": "sha512-MKRSh3GIHXCOMHskcZPdggY7O5GkBfLNoNt4HYe+08jR9/Kib8rEfd4ErKi9mbuWJbXciA84HLt3ebZpmydaKA==",
-      "dependencies": {
-        "@comunica/bus-rdf-parse": "^2.5.1",
-        "@comunica/types": "^2.5.1",
-        "rdfxml-streaming-parser": "^2.2.1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.5.1.tgz",
-      "integrity": "sha512-NbNaGcUepRz908nAVytKmTFn0dXOLdG88oD8ldI6Aw0HDvQU6Iw5r5eSaunfZONYYFT30eTZrGUyg3efwwfuvw==",
-      "dependencies": {
-        "@comunica/bus-rdf-parse": "^2.5.1",
-        "@comunica/types": "^2.5.1",
-        "rdfa-streaming-parser": "^2.0.1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/bus-http": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.5.1.tgz",
-      "integrity": "sha512-kouDqVoP6qAVQ4pflMmedBHfMtuLoBgqwX3mHdlUtrE0h1I+/EX6M5eUe5pXI6PfJrn3cInHyu+UZkbZYrykAw==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "is-stream": "^2.0.1",
-        "readable-stream-node-to-web": "^1.0.1",
-        "readable-web-to-node-stream": "^3.0.2",
-        "web-streams-ponyfill": "^1.4.2"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/bus-init": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.5.1.tgz",
-      "integrity": "sha512-TDakSkGzM+3xkZ+xBCBmzWNagmDWUc+F6TPYOFO8goaT1+tVrPh9wPD5t2n1zkKMzG2dOVT4O8jxUfCyzmNwKA==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "readable-stream": "^4.2.0"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/bus-rdf-parse": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.5.1.tgz",
-      "integrity": "sha512-BzfvedLkh1bOSa/WeUzLc/bQlcXWKhIkG/GwIOrCFtoWJOdOlapWdPvPS5U6sEW/UW454ClRWaqIA+GM0qeyzA==",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^2.5.1",
-        "@comunica/actor-abstract-parse": "^2.5.1",
-        "@comunica/core": "^2.5.1",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/bus-rdf-parse-html": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.5.1.tgz",
-      "integrity": "sha512-+YZiAbA2h82/+FGDJPjqHdfq6l0dm3W11V0jHcOaAsk+AK2JvvoouYdFAGshhroxQwv5WPsXbtzy6XJmVtZ4MQ==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/context-entries": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.5.1.tgz",
-      "integrity": "sha512-TnF476Nv9+DfZ+JLTQU7OSqmFREScVkpBtU71seT6He+vkJBHDm6Nq4tnKwDmAI3v9dCc5dgCRU4F2uPDjBKZA==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1",
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.2.2",
-        "sparqlalgebrajs": "^4.0.5"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-      "dependencies": {
-        "@comunica/types": "^2.5.1",
-        "immutable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/mediator-combine-pipeline": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.5.1.tgz",
-      "integrity": "sha512-vsi6YA7NGPQoNSPtKHWUbsDK+678w0BdE9DEzLWOa2pqiWoeT4SuJV4szHQNVuJjzi6j6VTXuR58mZL7XqreTw==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/mediator-combine-union": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.5.1.tgz",
-      "integrity": "sha512-vpbQn3xtoX+F00xv+AKbn+qUe66rIiycbiZoE/s/qtlmUbVKLItEMMuToDGRdcdC9mtPiieIrgremXd/RVdHTw==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/mediator-number": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.5.1.tgz",
-      "integrity": "sha512-pOTtj5WJEh8gNlNesxe7YG90J2dQobp8ulkzP/bzsd/DC14OOxYlcTke/c+GqZH6SaatUmz/R7Za5AWdipqYcw==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/mediator-race": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.5.1.tgz",
-      "integrity": "sha512-VuHHZSDagK9k85NBTEvbbhkb/Xd9zgt9jBlYIVRarushJ8ihqfs8dXQ2Hs0gdOTyrCMFiQIimbN1h58QcmmKyg==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/@comunica/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.13",
-        "asynciterator": "^3.8.0",
-        "sparqlalgebrajs": "^4.0.5"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/htmlparser2": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "entities": "^4.3.0"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/jsonld-streaming-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.0.1.tgz",
-      "integrity": "sha512-zSJlEgrKypQDk/85R+xkudeCZo6vmnvJuCPvcjk2BzHPLzv1yqiwoKQDyFzfgfgCHM0p7YCJBZl0liT9RMUZJw==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/http-link-header": "^1.0.1",
-        "@types/readable-stream": "^2.3.13",
-        "buffer": "^6.0.3",
-        "canonicalize": "^1.0.1",
-        "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.1.3",
-        "jsonparse": "^1.3.1",
-        "rdf-data-factory": "^1.1.0",
-        "readable-stream": "^4.0.0"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/microdata-rdf-streaming-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-2.0.1.tgz",
-      "integrity": "sha512-oEEYP3OwPGOtoE4eIyJvX1eJXI7VkGR4gKYqpEufaRXc2ele/Tkid/KMU3Los13wGrOq6woSxLEGOYSHzpRvwA==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "htmlparser2": "^8.0.0",
-        "rdf-data-factory": "^1.1.0",
-        "readable-stream": "^4.1.0",
-        "relative-to-absolute-iri": "^1.0.2"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/rdf-dereference": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rdf-dereference/-/rdf-dereference-2.0.1.tgz",
-      "integrity": "sha512-iiVAljvo4a/k48/TvqdHOTPmL83IBjYyRWizZQQZa50nGCvbbIvdh24LpvZQVF1g3fOB+SpGUktJAqQoUTt7Rw==",
-      "dependencies": {
-        "@comunica/actor-dereference-fallback": "^2.0.2",
-        "@comunica/actor-dereference-file": "^2.0.2",
-        "@comunica/actor-dereference-http": "^2.0.2",
-        "@comunica/actor-dereference-rdf-parse": "^2.0.2",
-        "@comunica/actor-http-fetch": "^2.0.1",
-        "@comunica/actor-http-proxy": "^2.0.1",
-        "@comunica/actor-rdf-parse-html": "^2.0.1",
-        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
-        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
-        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
-        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
-        "@comunica/actor-rdf-parse-n3": "^2.0.1",
-        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
-        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
-        "@comunica/bus-dereference": "^2.0.2",
-        "@comunica/bus-dereference-rdf": "^2.0.2",
-        "@comunica/bus-http": "^2.0.1",
-        "@comunica/bus-init": "^2.0.1",
-        "@comunica/bus-rdf-parse": "^2.0.1",
-        "@comunica/bus-rdf-parse-html": "^2.0.1",
-        "@comunica/config-query-sparql": "^2.0.1",
-        "@comunica/core": "^2.0.1",
-        "@comunica/mediator-combine-pipeline": "^2.0.1",
-        "@comunica/mediator-combine-union": "^2.0.1",
-        "@comunica/mediator-number": "^2.0.1",
-        "@comunica/mediator-race": "^2.0.1",
-        "@rdfjs/types": "*",
-        "rdf-string": "^1.6.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "bin": {
-        "rdf-dereference": "bin/Runner.js"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/rdf-parse": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.1.1.tgz",
-      "integrity": "sha512-JOTB7381bAdvab9ZM8IZq6Egj9tuTt7XSGlrQzDCFrlAjvc7z4cMxKawgk1kZaoS/CevNSrHYsyEaBwgNyl1KA==",
-      "dependencies": {
-        "@comunica/actor-http-fetch": "^2.0.1",
-        "@comunica/actor-http-proxy": "^2.0.1",
-        "@comunica/actor-rdf-parse-html": "^2.0.1",
-        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
-        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
-        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
-        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
-        "@comunica/actor-rdf-parse-n3": "^2.0.1",
-        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
-        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
-        "@comunica/bus-http": "^2.0.1",
-        "@comunica/bus-init": "^2.0.1",
-        "@comunica/bus-rdf-parse": "^2.0.1",
-        "@comunica/bus-rdf-parse-html": "^2.0.1",
-        "@comunica/config-query-sparql": "^2.0.1",
-        "@comunica/core": "^2.0.1",
-        "@comunica/mediator-combine-pipeline": "^2.0.1",
-        "@comunica/mediator-combine-union": "^2.0.1",
-        "@comunica/mediator-number": "^2.0.1",
-        "@comunica/mediator-race": "^2.0.1",
-        "@rdfjs/types": "*",
-        "stream-to-string": "^1.2.0"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/rdfa-streaming-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-2.0.1.tgz",
-      "integrity": "sha512-7Yyaj030LO7iQ38Wh/RNLVeYrVFJeyx3dpCK7C1nvX55eIN/gE4HWfbg4BYI9X7Bd+eUIUMVeiKYLmYjV6apow==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "htmlparser2": "^8.0.0",
-        "rdf-data-factory": "^1.1.0",
-        "readable-stream": "^4.0.0",
-        "relative-to-absolute-iri": "^1.0.2"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/rdfxml-streaming-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.2.1.tgz",
-      "integrity": "sha512-1r7aXfSRCLkBYXGcko/GpSZdHxXKvYaeUi2ulEbB7cLvACD7DNoAA/uW6dsETEhgmsEipJZI7NLqBl2whOse8Q==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/readable-stream": "^2.3.13",
-        "buffer": "^6.0.3",
-        "rdf-data-factory": "^1.1.0",
-        "readable-stream": "^4.0.0",
-        "relative-to-absolute-iri": "^1.0.0",
-        "saxes": "^6.0.0",
-        "validate-iri": "^1.0.0"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/readable-stream": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@dexagod/rdf-retrieval/node_modules/sparqlalgebrajs": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-      "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.3",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.6",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.6.1"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@digitalbazaar/http-client": {
@@ -4172,10 +2467,26 @@
         "node": "^14.0.0 || ^16.0.0"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
+    "node_modules/@jeswr/prefixcc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jeswr/prefixcc/-/prefixcc-1.2.1.tgz",
+      "integrity": "sha512-kBBXbqsaeh3Irp416h/RbelqJgIOp6X/OJJlYmLyr/9qlBYKTKSCuEv5/xjZ0Yf8Yec+QFRYBaOQ2JkMBSH7KA==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "peer": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
@@ -4205,9 +2516,9 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
       "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -4221,13 +2532,24 @@
       "peer": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
       "peer": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@koa/cors": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-3.4.3.tgz",
+      "integrity": "sha512-WPXQUaAeAMVaLTEFpoq3T2O1C+FstkjJnDQqy95Ck1UdILajsRhu6mhJ8H2f4NFPRBoCNN+qywTJfq/gGki5mw==",
+      "dependencies": {
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4313,6 +2635,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/@rdf-esm/term-map/node_modules/@rdfjs/to-ntriples": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
+      "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q=="
+    },
     "node_modules/@rdf-esm/term-set": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@rdf-esm/term-set/-/term-set-0.5.0.tgz",
@@ -4379,6 +2706,19 @@
         "readable-to-readable": "^0.1.0"
       }
     },
+    "node_modules/@rdfjs/parser-n3/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@rdfjs/sink": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-1.0.3.tgz",
@@ -4395,6 +2735,11 @@
         "@rdfjs/to-ntriples": "^2.0.0"
       }
     },
+    "node_modules/@rdfjs/term-map/node_modules/@rdfjs/to-ntriples": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
+      "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q=="
+    },
     "node_modules/@rdfjs/term-set": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-1.1.0.tgz",
@@ -4403,10 +2748,18 @@
         "@rdfjs/to-ntriples": "^2.0.0"
       }
     },
-    "node_modules/@rdfjs/to-ntriples": {
+    "node_modules/@rdfjs/term-set/node_modules/@rdfjs/to-ntriples": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
       "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q=="
+    },
+    "node_modules/@rdfjs/to-ntriples": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz",
+      "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@rdfjs/types": {
       "version": "1.1.0",
@@ -4414,6 +2767,17 @@
       "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@rubensworks/saxes": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rubensworks/saxes/-/saxes-6.0.1.tgz",
+      "integrity": "sha512-UW4OTIsOtJ5KSXo2Tchi4lhZqu+tlHrOAs4nNti7CrtB53kAZl3/hyrTi6HkMihxdbDM6m2Zc3swc/ZewEe1xw==",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.12"
       }
     },
     "node_modules/@rubensworks/solid-client-authn-isomorphic": {
@@ -4424,6 +2788,158 @@
         "@inrupt/solid-client-authn-browser": "^1.12.1",
         "@inrupt/solid-client-authn-core": "^1.12.1",
         "@inrupt/solid-client-authn-node": "^1.12.1"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@solid/access-control-policy": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@solid/access-control-policy/-/access-control-policy-0.1.3.tgz",
+      "integrity": "sha512-LTxfN8N5hNBNYfuwJr0nyfxlp2P0+GeK+biCa1FQgIqska3wXpTgYaxjVgsw27mKx4N1FOlaGwG+nXdLnl9ykg=="
+    },
+    "node_modules/@solid/access-token-verifier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@solid/access-token-verifier/-/access-token-verifier-2.0.5.tgz",
+      "integrity": "sha512-YsoMmEk7pN6tlCHcDm5iLa9ZYvTYvuk3SX5cz18XW1qYmM46znEGnXz94vm7DIa7DcTLGi9suMw7M5pRs2xOLw==",
+      "dependencies": {
+        "jose": "^4.10.3",
+        "lru-cache": "^6.0.0",
+        "n3": "^1.16.2",
+        "node-fetch": "^2.6.7",
+        "ts-guards": "^0.5.1"
+      }
+    },
+    "node_modules/@solid/community-server": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@solid/community-server/-/community-server-6.0.1.tgz",
+      "integrity": "sha512-Ll/CokpMTjFAKt1QzmeEW8QPnzUaU/X1X/T8GwMcF9O3Da2qIWRU0negMN3DKFFVTuZK6Kj1swrFxOwbo29oRQ==",
+      "dependencies": {
+        "@comunica/context-entries": "^2.6.8",
+        "@comunica/query-sparql": "^2.6.9",
+        "@rdfjs/types": "^1.1.0",
+        "@solid/access-control-policy": "^0.1.3",
+        "@solid/access-token-verifier": "^2.0.5",
+        "@types/async-lock": "^1.4.0",
+        "@types/bcryptjs": "^2.4.2",
+        "@types/cors": "^2.8.12",
+        "@types/ejs": "^3.1.2",
+        "@types/end-of-stream": "^1.4.1",
+        "@types/fs-extra": "^11.0.1",
+        "@types/lodash.orderby": "^4.6.7",
+        "@types/marked": "^4.0.8",
+        "@types/mime-types": "^2.1.1",
+        "@types/n3": "^1.10.4",
+        "@types/node": "^14.18.43",
+        "@types/nodemailer": "^6.4.7",
+        "@types/oidc-provider": "^7.11.1",
+        "@types/proper-lockfile": "^4.1.2",
+        "@types/pump": "^1.1.1",
+        "@types/punycode": "^2.1.0",
+        "@types/rdf-validate-shacl": "^0.4.1",
+        "@types/sparqljs": "^3.1.4",
+        "@types/url-join": "^4.0.1",
+        "@types/uuid": "^9.0.1",
+        "@types/ws": "^8.5.4",
+        "@types/yargs": "^17.0.24",
+        "arrayify-stream": "^2.0.1",
+        "async-lock": "^1.4.0",
+        "bcryptjs": "^2.4.3",
+        "componentsjs": "^5.3.2",
+        "cors": "^2.8.5",
+        "cross-fetch": "^3.1.5",
+        "ejs": "^3.1.9",
+        "end-of-stream": "^1.4.4",
+        "escape-string-regexp": "^4.0.0",
+        "fetch-sparql-endpoint": "^3.2.1",
+        "fs-extra": "^11.1.1",
+        "handlebars": "^4.7.7",
+        "ioredis": "^5.3.2",
+        "iso8601-duration": "^2.1.1",
+        "jose": "^4.14.1",
+        "jsonld-context-parser": "^2.3.0",
+        "lodash.orderby": "^4.6.0",
+        "marked": "^4.3.0",
+        "mime-types": "^2.1.35",
+        "n3": "^1.16.4",
+        "nodemailer": "^6.9.1",
+        "oidc-provider": "7.10.6",
+        "proper-lockfile": "^4.1.2",
+        "pump": "^3.0.0",
+        "punycode": "^2.1.1",
+        "rdf-dereference": "^2.1.0",
+        "rdf-parse": "^2.3.2",
+        "rdf-serialize": "^2.2.2",
+        "rdf-string": "^1.6.3",
+        "rdf-terms": "^1.9.1",
+        "rdf-validate-shacl": "^0.4.5",
+        "sparqlalgebrajs": "^4.0.5",
+        "sparqljs": "^3.6.2",
+        "url-join": "^4.0.1",
+        "uuid": "^9.0.0",
+        "winston": "^3.8.2",
+        "winston-transport": "^4.5.0",
+        "ws": "^8.13.0",
+        "yargs": "^17.7.1"
+      },
+      "bin": {
+        "community-solid-server": "bin/server.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@solid/community-server/node_modules/@types/node": {
+      "version": "14.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.53.tgz",
+      "integrity": "sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A=="
+    },
+    "node_modules/@solid/community-server/node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
+    },
+    "node_modules/@solid/community-server/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@solid/community-server/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@tpluscode/rdf-ns-builders": {
@@ -4457,47 +2973,47 @@
       }
     },
     "node_modules/@tpluscode/rdf-string": {
-      "version": "0.2.26",
-      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-string/-/rdf-string-0.2.26.tgz",
-      "integrity": "sha512-zfNGMmY8D9jVuJ9qHwNrIWMwhibIkO42/1KtCfo59m4vXYTfJrXcn1ny9pj5kuhbpSubRbJ69zmYxP4UrXVPQw==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-string/-/rdf-string-0.2.27.tgz",
+      "integrity": "sha512-+h7FdEE9AwP+B0kA2u0lScWq0+wIfpAcsau6cHZRQfToTCQjq+xo5eyGqzC96SmVfULl73DHys5DE/VOtA3Ewg==",
       "dependencies": {
         "@rdf-esm/data-model": "^0.5.3",
         "@rdf-esm/term-map": "^0.5.0",
         "@rdfjs/types": "*",
         "@tpluscode/rdf-ns-builders": "^2",
-        "@zazuko/rdf-vocabularies": "*"
+        "@zazuko/rdf-vocabularies": ">=2023.01.17"
       }
     },
     "node_modules/@treecg/actor-init-ldes-client": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@treecg/actor-init-ldes-client/-/actor-init-ldes-client-2.6.0.tgz",
-      "integrity": "sha512-0KfIMwKKVgqgJb6b+Uf3YRACArdGCIWKDBlGNKkzSRbe0ShKBZ2XDMbMA6PgM/oxELEAImTcDXKQUvzBwdK8Rg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@treecg/actor-init-ldes-client/-/actor-init-ldes-client-3.0.2.tgz",
+      "integrity": "sha512-vkYU14GS8ZePkUDoniuRMT7puKc+iyEf1TlIr8XG82uYhyQnhP5dPNG3Z5lylbWDBwVxRb1eY+5rIc31zJOI4g==",
       "dependencies": {
-        "@comunica/actor-http-node-fetch": "1.21.2",
-        "@comunica/actor-http-proxy": "1.21.1",
-        "@comunica/actor-init-sparql": "1.21.3",
-        "@comunica/actor-rdf-dereference-http-parse": "1.21.2",
-        "@comunica/actor-rdf-parse-jsonld": "1.21.2",
-        "@comunica/actor-rdf-parse-n3": "1.21.1",
-        "@comunica/bus-http": "1.21.1",
-        "@comunica/bus-init": "1.21.1",
-        "@comunica/bus-rdf-dereference": "1.21.1",
-        "@comunica/bus-rdf-metadata-extract": "1.21.1",
-        "@comunica/bus-rdf-parse": "1.21.1",
-        "@comunica/core": "1.21.1",
-        "@comunica/mediator-combine-union": "1.21.1",
-        "@comunica/mediator-number": "1.21.1",
-        "@comunica/mediator-race": "1.21.1",
-        "@comunica/runner": "1.21.1",
-        "@comunica/runner-cli": "1.21.1",
-        "@dexagod/rdf-retrieval": "^1.0.2",
-        "@rdfjs/data-model": "1.3.3",
-        "@treecg/actor-rdf-filter-object-with-framing": "^2.3.6",
-        "@treecg/actor-rdf-filter-objects-with-quadstore": "^2.3.6",
-        "@treecg/actor-rdf-frame-with-json-ld-js": "^2.6.0",
-        "@treecg/actor-rdf-metadata-extract-tree": "^1.20.0",
-        "@treecg/bus-rdf-filter-object": "^2.3.6",
-        "@treecg/bus-rdf-frame": "^2.6.0",
+        "@comunica/actor-dereference-rdf-parse": "^2.3.0",
+        "@comunica/actor-http-fetch": "^2.3.0",
+        "@comunica/actor-http-proxy": "^2.3.0",
+        "@comunica/actor-rdf-parse-jsonld": "^2.3.0",
+        "@comunica/actor-rdf-parse-n3": "^2.3.0",
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-init": "^2.3.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/mediator-combine-union": "^2.3.0",
+        "@comunica/mediator-number": "^2.3.0",
+        "@comunica/mediator-race": "^2.3.0",
+        "@comunica/query-sparql": "^2.3.0",
+        "@comunica/runner": "^2.3.0",
+        "@comunica/runner-cli": "^2.3.0",
+        "@dexagod/rdf-retrieval": "^1.0.3",
+        "@rdfjs/data-model": "^2.0.1",
+        "@treecg/actor-rdf-filter-object-with-framing": "^3.0.0",
+        "@treecg/actor-rdf-filter-objects-with-quadstore": "^3.0.0",
+        "@treecg/actor-rdf-frame-with-json-ld-js": "^3.0.0",
+        "@treecg/actor-rdf-metadata-extract-tree": "^2.0.0",
+        "@treecg/bus-rdf-filter-object": "^3.0.0",
+        "@treecg/bus-rdf-frame": "^3.0.0",
         "@treecg/types": "^0.2.2",
         "awesome-typescript-loader": "^5.2.1",
         "cacheable-request": "^7.0.1",
@@ -4507,77 +3023,73 @@
         "lru-cache": "^6.0.0",
         "moment": "^2.29.1",
         "n3": "^1.8.0",
-        "rdf-dereference": "^1.8.0",
+        "rdf-dereference": "^2.0.0",
         "rdf-string": "^1.6.0",
         "source-map-loader": "^2.0.0",
         "streamify-string": "^1.0.1",
-        "typescript": "^4.1.3"
+        "typescript": "^4.7.4"
       },
       "bin": {
         "actor-init-ldes-client": "bin/run.js"
       }
     },
     "node_modules/@treecg/actor-init-ldes-client/node_modules/@rdfjs/data-model": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.3.tgz",
-      "integrity": "sha512-oo9U3nEowTxxML7CZybujL3e/bty4aXHDSWanWXQxfnJQYKU6p5SCgkjeRbuVfQ9lAVfdvz68Qq5D4LtGWuKug==",
-      "dependencies": {
-        "@types/rdf-js": "*"
-      },
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
+      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
       "bin": {
         "rdfjs-data-model-test": "bin/test.js"
       }
     },
-    "node_modules/@treecg/actor-init-ldes-client/node_modules/@treecg/bus-rdf-filter-object": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-filter-object/-/bus-rdf-filter-object-2.3.6.tgz",
-      "integrity": "sha512-sIHoQvOG1ElVaNe5M44Za5gV0Q1aQNvt975+cFyjzRCTcqdoCLUPOfEZwpBdqgvbbyOFphUj8ytfKOng/xQ/iw==",
-      "peerDependencies": {
-        "@comunica/core": "1.21.1"
-      }
-    },
-    "node_modules/@treecg/actor-init-ldes-client/node_modules/@treecg/bus-rdf-frame": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-frame/-/bus-rdf-frame-2.6.0.tgz",
-      "integrity": "sha512-n44CYCbzie37WtIia1PoBMJi8aYan5hUbKh9dbF6MTF9GJ3Tc5bnNRDOvG8bhK61FjFD924SWNm82v34w1/R1w==",
-      "peerDependencies": {
-        "@comunica/core": "1.21.1"
+    "node_modules/@treecg/actor-init-ldes-client/node_modules/@treecg/types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@treecg/types/-/types-0.2.5.tgz",
+      "integrity": "sha512-sIY++4YL4QCWisq/8YozbqMQpomHDkZmw3qoWy/7bSSlwaSVks8g0Zwfv92IALWz9Lq1EtRqyv3jAaCyDtctkw==",
+      "dependencies": {
+        "@rdfjs/dataset": "^1.1.1",
+        "@rdfjs/types": "*",
+        "@types/node": "*",
+        "clownface": "^1.4.0",
+        "clownface-shacl-path": "^1.2.2",
+        "loglevel": "^1.8.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "n3": "^1.11.1",
+        "rdf-data-factory": "^1.1.0",
+        "winston": "^3.3.3"
       }
     },
     "node_modules/@treecg/actor-rdf-filter-object-with-framing": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-filter-object-with-framing/-/actor-rdf-filter-object-with-framing-2.3.6.tgz",
-      "integrity": "sha512-wv6HEPbenyH/UhjpPrC0n6VS1IFWYiik3LcfO7E0fmHl6mzZMaK/rYuVGH6uYaq2nJBOCoUbpoVHYeOIsjII+w==",
-      "peerDependencies": {
-        "@comunica/core": "1.21.1",
-        "@treecg/bus-rdf-filter-object": "2.3.4"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-filter-object-with-framing/-/actor-rdf-filter-object-with-framing-3.0.0.tgz",
+      "integrity": "sha512-aRn7R+nTyxVcdiJL7O8Y12Ea5Ek3y+fEMyupMV1a11NwtLq0o5esQ8T2HglOqW2TD9tkTnxEPChLtlFaGJjriQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@treecg/bus-rdf-filter-object": "^3.0.0",
+        "@treecg/bus-rdf-frame": "^3.0.0",
+        "@types/rdf-js": "^4.0.2"
       }
     },
     "node_modules/@treecg/actor-rdf-filter-objects-with-quadstore": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-filter-objects-with-quadstore/-/actor-rdf-filter-objects-with-quadstore-2.3.6.tgz",
-      "integrity": "sha512-bkT6yD0tfoj7k4VCQ1AaCA6NSVDgzzWaK20te3e7ikg7nu+m89AV/7rkuJgyqJp8BfVUQj6kuzrhY9b/jdJsuA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-filter-objects-with-quadstore/-/actor-rdf-filter-objects-with-quadstore-3.0.0.tgz",
+      "integrity": "sha512-nruV/Y5rPXkDm1GF4sOwkJBL4+cGDRaX3PXukG5xY1z+e772b8V4j7Y0HQaJMPo4tW4aPTwUbJNbtjA3DEjDfg==",
       "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@treecg/bus-rdf-filter-object": "^3.0.0",
+        "@types/rdf-js": "^4.0.2",
         "n3": "^1.10.0",
         "rdf-store-stream": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "1.21.1",
-        "@treecg/bus-rdf-filter-object": "2.3.4"
       }
     },
     "node_modules/@treecg/actor-rdf-frame-with-json-ld-js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-frame-with-json-ld-js/-/actor-rdf-frame-with-json-ld-js-2.6.0.tgz",
-      "integrity": "sha512-Y/1ypXzGJpxRPX0PMf1xYS1yYa804VY+JAimfTIgwjhdIVroLtwvxH+UZ3Xch99ksI/U/9F1vowe2Y2d/ksy/g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-frame-with-json-ld-js/-/actor-rdf-frame-with-json-ld-js-3.0.0.tgz",
+      "integrity": "sha512-H+4DeQ8CHgnSLjIcHqhxplkysHNHTTySRL4fy6o13zcWcF211U1jdpHrfBYwtv3qiJJvy4XTkV7pxC3UEhC7gQ==",
       "dependencies": {
         "@types/jsonld": "^1.5.4",
         "jsonld": "^4.0.1",
         "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "1.21.1",
-        "@treecg/bus-rdf-frame": "2.3.4"
       }
     },
     "node_modules/@treecg/actor-rdf-frame-with-json-ld-js/node_modules/jsonld": {
@@ -4630,44 +3142,52 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/@treecg/actor-rdf-metadata-extract-tree": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-metadata-extract-tree/-/actor-rdf-metadata-extract-tree-1.20.0.tgz",
-      "integrity": "sha512-BUAbTsHczPR0GbAMznxIgzKm9BqB6B2Q9TQeNjsqDHpfVe0NffggGk3ma/P1XrerL+NsAxO5AS2z76MZtzFpBw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-metadata-extract-tree/-/actor-rdf-metadata-extract-tree-2.0.0.tgz",
+      "integrity": "sha512-15ysrCQ2vx+UN1yCtx9g4T6nj7QiHjPDd/r/KUwcrdTzTktz/z3bOSIojxugMCW6PrxxUqTEVx5I506TSamq8A==",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-extract": "1.21.1",
-        "@comunica/core": "1.21.1",
-        "@treecg/tree-metadata-extraction": "^1.1.1"
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@treecg/tree-metadata-extraction": "^1.2.1",
+        "typescript": "^4.7.4"
       }
     },
     "node_modules/@treecg/bus-rdf-filter-object": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-filter-object/-/bus-rdf-filter-object-2.3.4.tgz",
-      "integrity": "sha512-ctNZcWxttC9bOiD1E2+fAl6RJeaBrI2wyg9YHoYrGU2/pXzFqK3PzuqPyxe0LcBtnbKnw++SrkzNwDCNlqvCNQ==",
-      "peer": true,
-      "peerDependencies": {
-        "@comunica/core": "^1.19.2"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-filter-object/-/bus-rdf-filter-object-3.0.0.tgz",
+      "integrity": "sha512-j0xDopxWwfK8RamhisWYCXtFmZDwOcQfYgy8WG6b3D2Hj3INGK1dN1rSLOz8O+UEEKfA6mwmc6hQpPHwkdq3Pg==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
       }
     },
     "node_modules/@treecg/bus-rdf-frame": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-frame/-/bus-rdf-frame-2.3.4.tgz",
-      "integrity": "sha512-ZBBEkKt039bwiE4/cQdjtcOU8yE2TThrs7RkBuqDQEEfFngcafNkHoin1DO1sC2vIZTZiGOq1/t1I4fgu0uyBA==",
-      "peer": true,
-      "peerDependencies": {
-        "@comunica/core": "^1.19.2"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-frame/-/bus-rdf-frame-3.0.0.tgz",
+      "integrity": "sha512-rFM5ZM2jn04erD3uLYmxY0CVlssFaUlv7Bpr5pxJM9MWC1gA9xwjOMls1aAggjaZIE+YeA+j7E0ZnVoYBMdujg==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
       }
     },
     "node_modules/@treecg/ldes-snapshot": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@treecg/ldes-snapshot/-/ldes-snapshot-0.0.5.tgz",
-      "integrity": "sha512-J5F27eWkZwmJyi9AKtLdIhrZ3U+ARSsotuEIc2PXuKzJtux1oaSX5hQhNDyvpnvEEZccanafS7U/5qJC4W9EPw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@treecg/ldes-snapshot/-/ldes-snapshot-0.1.1.tgz",
+      "integrity": "sha512-cYt68FCgjg5M9JbRHyIzL5M01UhuwouMVTdbA4Vct5V89KwPopYUwhLbOmN4z88tHqbzo/WZWw0QZ98Sgx1Ldw==",
       "dependencies": {
-        "@treecg/version-materialize-rdf.js": "^0.0.2",
+        "@rdfjs/data-model": "^2.0.1",
+        "@treecg/version-materialize-rdf.js": "^0.0.3",
         "loglevel": "^1.8.0",
         "loglevel-plugin-prefix": "^0.8.4",
         "n3": "^1.13.0",
-        "rdf-parse": "^1.9.1",
+        "rdf-parse": "^2.3.0",
         "typescript": "^4.6.2"
+      }
+    },
+    "node_modules/@treecg/ldes-snapshot/node_modules/@rdfjs/data-model": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
+      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
       }
     },
     "node_modules/@treecg/tree-metadata-extraction": {
@@ -4679,28 +3199,22 @@
       }
     },
     "node_modules/@treecg/types": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@treecg/types/-/types-0.2.5.tgz",
-      "integrity": "sha512-sIY++4YL4QCWisq/8YozbqMQpomHDkZmw3qoWy/7bSSlwaSVks8g0Zwfv92IALWz9Lq1EtRqyv3jAaCyDtctkw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@treecg/types/-/types-0.4.5.tgz",
+      "integrity": "sha512-vPEVVlRDPQz8KwQmC6SKW5cTgggrBmEapw1Plg7beVX6pmfM1bll7lMnHGNLJDmoDyfAkR6LV4nB/VLGpjGBPA==",
       "dependencies": {
-        "@rdfjs/dataset": "^1.1.1",
         "@rdfjs/types": "*",
-        "@types/node": "*",
-        "clownface": "^1.4.0",
-        "clownface-shacl-path": "^1.2.2",
-        "loglevel": "^1.8.0",
+        "loglevel": "^1.8.1",
         "loglevel-plugin-prefix": "^0.8.4",
-        "n3": "^1.11.1",
-        "rdf-data-factory": "^1.1.0",
-        "winston": "^3.3.3"
+        "rdf-data-factory": "^1.1.0"
       }
     },
     "node_modules/@treecg/version-materialize-rdf.js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@treecg/version-materialize-rdf.js/-/version-materialize-rdf.js-0.0.2.tgz",
-      "integrity": "sha512-A4XzscAE4+P9JmfIYe1pTmJfdTFtA+PyJ1XwBNIKps7lZ4AOaZPTCufUcH90ltkkiTOxoFqK5PLhfehxDwAlhw==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@treecg/version-materialize-rdf.js/-/version-materialize-rdf.js-0.0.3.tgz",
+      "integrity": "sha512-yPNiW0YP2JhuxaV3i6ltSDxWfrAyfSn0UspsiUjASPWn8JIhr/aF0P7mF3aFm5/AILCaBkuxSV4ibNvQLOElDw==",
       "dependencies": {
-        "@treecg/actor-init-ldes-client": "^2.3.7",
+        "@treecg/actor-init-ldes-client": "^3.0.1",
         "commander": "^8.1.0",
         "rdf-data-factory": "^1.1.0"
       },
@@ -4709,25 +3223,29 @@
       }
     },
     "node_modules/@treecg/versionawareldesinldp": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@treecg/versionawareldesinldp/-/versionawareldesinldp-0.0.2.tgz",
-      "integrity": "sha512-DtLjQsocoU6E9wlqXm23PTcUm7ZKpcISQY+UHMW7SRtBVN3tgMv10xtqiLo8qhGgw5iI1cZNcvz2ssHxUUH+/w==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@treecg/versionawareldesinldp/-/versionawareldesinldp-0.2.1.tgz",
+      "integrity": "sha512-XFEMzCqnWJ5gmB/3D6ZeUrzf3iN3DmhE8XOn8UadbkdnCmyV5BW5hs+4LaXwaUC+wTFM6XYat0W6CpVKOTPd9w==",
       "dependencies": {
         "@inrupt/solid-client-authn-node": "1.12.1",
         "@rdfjs/data-model": "^1.3.4",
-        "@rubensworks/solid-client-authn-isomorphic": "^1.0.0",
-        "@treecg/ldes-snapshot": "^0.0.5",
-        "@treecg/types": "^0.2.2",
-        "componentsjs": "^4.5.0",
-        "componentsjs-generator": "^2.6.1",
+        "@rubensworks/solid-client-authn-isomorphic": "^2.0.0",
+        "@treecg/ldes-snapshot": "^0.1.1",
+        "@treecg/types": "^0.4.0",
+        "componentsjs": "^5.3.2",
+        "componentsjs-generator": "^3.1.0",
         "dotenv": "^16.0.1",
+        "express": "^4.17.3",
         "loglevel": "^1.8.0",
         "loglevel-plugin-prefix": "^0.8.4",
         "n3": "^1.14.0",
-        "rdf-store-stream": "^1.3.0",
+        "parse-link-header": "^2.0.0",
+        "rdf-store-stream": "^1.3.1",
         "streamify-string": "^1.0.1",
+        "tinyduration": "^3.2.3",
         "typescript": "^4.6.2",
         "uuid": "^8.3.2",
+        "wac-allow": "^1.0.0",
         "yargs": "^17.4.1"
       }
     },
@@ -4746,16 +3264,6 @@
         "node": ">=14.0"
       }
     },
-    "node_modules/@treecg/versionawareldesinldp/node_modules/@rubensworks/solid-client-authn-isomorphic": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rubensworks/solid-client-authn-isomorphic/-/solid-client-authn-isomorphic-1.0.0.tgz",
-      "integrity": "sha512-Wv6teAK4u8efRl6GVGofp542+ljGl6RvvR/l/buCDAZ/07zlSEXzXWEprMWcGN5SHkeZaAHMq2rVVR5RGZ2Fyw==",
-      "dependencies": {
-        "@inrupt/solid-client-authn-browser": "^1.11.2",
-        "@inrupt/solid-client-authn-core": "^1.11.2",
-        "@inrupt/solid-client-authn-node": "^1.11.2"
-      }
-    },
     "node_modules/@treecg/versionawareldesinldp/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -4765,14 +3273,14 @@
       }
     },
     "node_modules/@ts-morph/common": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.18.1.tgz",
-      "integrity": "sha512-RVE+zSRICWRsfrkAw5qCAK+4ZH9kwEFv5h0+/YeHTLieWP7F4wWq4JsKFuNWG+fYh/KF+8rAtgdj5zb2mm+DVA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.20.0.tgz",
+      "integrity": "sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==",
       "peer": true,
       "dependencies": {
         "fast-glob": "^3.2.12",
-        "minimatch": "^5.1.0",
-        "mkdirp": "^1.0.4",
+        "minimatch": "^7.4.3",
+        "mkdirp": "^2.1.6",
         "path-browserify": "^1.0.1"
       }
     },
@@ -4786,27 +3294,33 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
       "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@ts-morph/common/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
       "peer": true,
       "bin": {
-        "mkdirp": "bin/cmd.js"
+        "mkdirp": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -4828,16 +3342,33 @@
       "peer": true
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "peer": true
+    },
+    "node_modules/@types/accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/async-lock": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.0.tgz",
+      "integrity": "sha512-2+rYSaWrpdbQG3SA0LmMT6YxWLrI81AqpMlSkw3QtFc2HGDufkweQSn30Eiev7x9LL0oyFrBqk1PXOnB9IEgKg=="
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
+      "integrity": "sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -4848,19 +3379,74 @@
       "resolved": "https://registry.npmjs.org/@types/browser-or-node/-/browser-or-node-1.3.0.tgz",
       "integrity": "sha512-MVetr65IR7RdJbUxVHsaPFaXAO8fi89zv1g8L/mHygh1Q7xnnK02XZLwfMh57FOpTO6gtnagoPMQ/UOFfctXRQ=="
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/clownface": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/clownface/-/clownface-1.5.2.tgz",
+      "integrity": "sha512-c/BLyUFSuzgmbQ0kBlxNf9HEkDdCk4tMxUxWjtGSpvLMXM3t5KrJabcGkDStmfzA+bHFHwHHikyWsZYVC1TuWw==",
+      "dependencies": {
+        "rdf-js": "^4.0.2"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/content-disposition": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
+      "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA=="
+    },
+    "node_modules/@types/cookies": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
+      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ejs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.2.tgz",
+      "integrity": "sha512-ZmiaE3wglXVWBM9fyVC17aGPkLo/UgaOjEiI2FXQfyczrCefORPxIe+2dVmnmk3zkVIbizjrlQzmPGhSYGXG5g=="
+    },
+    "node_modules/@types/end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@types/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-dYCSlUtCGXuP2axeKD5l1vj/04iNXW8TLXryDa0uA8u8EsNE68jn27ZLg7jAPV+qJAlk1wC4WtRdIoZXvuUl0A==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.4.10",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
-      "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
+      "version": "8.40.2",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.2.tgz",
+      "integrity": "sha512-PRVjQ4Eh9z9pmmtaq8nTjZjQwKFk7YIHIud3lRoKRBgUQjgjRmoGxxGEPXQkF+lH7QkHJRNr5F4aBgYCW0lqpQ==",
       "peer": true,
       "dependencies": {
         "@types/estree": "*",
@@ -4878,16 +3464,15 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
       "peer": true
     },
     "node_modules/@types/express": {
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
       "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
-      "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -4899,12 +3484,35 @@
       "version": "4.17.31",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
       "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.1.tgz",
+      "integrity": "sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==",
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-assert": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.3.tgz",
+      "integrity": "sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA=="
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
     },
     "node_modules/@types/http-link-header": {
       "version": "1.0.3",
@@ -4919,10 +3527,54 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.1.tgz",
+      "integrity": "sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/jsonld": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.8.tgz",
-      "integrity": "sha512-4l5t/jDnJpqZ+i7CLTTgPcT5BYXnAnwJupb07aAokPufCV0SjDHcwctUkSTuhIuSU9yHok+WOOngIGCtpL96gw=="
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.9.tgz",
+      "integrity": "sha512-K76ImkErPYL2wGPZpNFSKp6wE+h/APecZLJrU7UfDaGqt/f+D9Rrg1aR7VdRrQ6k5DUNRZ2vn9yACwmpOr9QcA=="
+    },
+    "node_modules/@types/keygrip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/koa": {
+      "version": "2.13.6",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.6.tgz",
+      "integrity": "sha512-diYUfp/GqfWBAiwxHtYJ/FQYIXhlEhlyaU7lB/bWQrx4Il9lCET5UwpFy3StOAohfsxxvEQ11qIJgT1j2tfBvw==",
+      "dependencies": {
+        "@types/accepts": "*",
+        "@types/content-disposition": "*",
+        "@types/cookies": "*",
+        "@types/http-assert": "*",
+        "@types/http-errors": "*",
+        "@types/keygrip": "*",
+        "@types/koa-compose": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/koa-compose": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
+      "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
+      "dependencies": {
+        "@types/koa": "*"
+      }
     },
     "node_modules/@types/lodash": {
       "version": "4.14.191",
@@ -4937,16 +3589,37 @@
         "@types/lodash": "*"
       }
     },
+    "node_modules/@types/lodash.orderby": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.orderby/-/lodash.orderby-4.6.7.tgz",
+      "integrity": "sha512-GaaUBTS4RTjL8gz1ZXkwAB/defpGMOWwCG9C4HL9g81i4wghIoVVESQCUa1xRsyUBqAb5JwLbSwvL0q36rK0sA==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+      "version": "7.10.10",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-7.10.10.tgz",
+      "integrity": "sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==",
+      "deprecated": "This is a stub types definition. lru-cache provides its own type definitions, so you do not need this installed.",
+      "dependencies": {
+        "lru-cache": "*"
+      }
+    },
+    "node_modules/@types/marked": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.1.tgz",
+      "integrity": "sha512-vSSbKZFbNktrQ15v7o1EaH78EbWV+sPQbPjHG+Cp8CaNcPFUEfjZ0Iml/V0bFDwsTlYe8o6XC5Hfdp91cqPV2g=="
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-      "dev": true
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
+    },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.1.tgz",
+      "integrity": "sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw=="
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -4967,22 +3640,52 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.14.tgz",
       "integrity": "sha512-0KXV57tENYmmJMl+FekeW9V3O/rlcqGQQJ/hNh9r8pKIj304pskWuEd8fCyNT86g/TpO0gcOTiLzsHLEURFMIQ=="
     },
-    "node_modules/@types/parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha512-E2+Go9rQgPbmpkeA2iFXTWSTxX38KXlXwcdiIbt71Oorqr+G5QtH4AhpuDdxwRVyiTzdUrHnaaIumW/LhiZwVg=="
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.8.tgz",
+      "integrity": "sha512-oVsJSCkqViCn8/pEu2hfjwVO+Gb3e+eTWjg3PcjeFKRItfKpKwHphQqbYmPQrlMk+op7pNNWPbsJIEthpFN/OQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/oidc-provider": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@types/oidc-provider/-/oidc-provider-7.14.0.tgz",
+      "integrity": "sha512-zIoedB25LuuiNb0tqRQYI3BzdHXVCsZrCHm38apiLe1p6TmbZA7dCSv8rH3AR8xyBk7eNiE+iIBDEHlBx4UzPA==",
+      "dependencies": {
+        "@types/koa": "*"
+      }
+    },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-kd4LMvcnpYkspDcp7rmXKedn8iJSCoa331zRRamUp5oanKt/CefbEGPQP7G89enz7sKD4bvsr8mHSsC8j5WOvA==",
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
+    "node_modules/@types/pump": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/pump/-/pump-1.1.1.tgz",
+      "integrity": "sha512-wpRerjHDxFBQ4r8XNv3xHJZeuqrBBoeQ/fhgkooV2F7KsPIYRROb/+f9ODgZfOEyO5/w2ej4YQdpPPXipT8DAA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha512-PG5aLpW6PJOeV2fHRslP4IOMWn+G+Uq8CfnyJ+PDS8ndCbU+soO+fB3NKCKo0p/Jh2Y4aPaiQZsrOXFdzpcA6g=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/rdf-dataset-indexed": {
       "version": "0.4.6",
@@ -5010,6 +3713,15 @@
         "rdf-js": "*"
       }
     },
+    "node_modules/@types/rdf-validate-shacl": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@types/rdf-validate-shacl/-/rdf-validate-shacl-0.4.2.tgz",
+      "integrity": "sha512-txAtt8VBUMp6tO41aeJtbf6sgvM1n1LTC7rhmfO9ili7eoAe0wlNXGjo+1RLtb9pHWe9s2SnRAxFFbOY5A5I/A==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/clownface": "*"
+      }
+    },
     "node_modules/@types/rdfjs__dataset": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-1.0.5.tgz",
@@ -5019,11 +3731,11 @@
       }
     },
     "node_modules/@types/rdfjs__namespace": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.0.tgz",
-      "integrity": "sha512-bpVmmBrwg4plwfSNtwbwIYtZEpGFPWHTlfa1iftSY03+V+2wq+pfZxYkZwrhZwyh/Dxy5usIrVt04Rvigc4uXg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.3.tgz",
+      "integrity": "sha512-qJ8KpDby8p6STR8ZeDrhVDfzAnwII0txlrLhCsZz/V+3Mbsz0GzUiY8654ENzCicbjd+ZY8PNiS2fHZ/evY3Dw==",
       "dependencies": {
-        "rdf-js": "^4.0.2"
+        "@rdfjs/types": "*"
       }
     },
     "node_modules/@types/readable-stream": {
@@ -5040,6 +3752,19 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "node_modules/@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="
+    },
     "node_modules/@types/semver": {
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
@@ -5049,7 +3774,6 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
       "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
-      "dev": true,
       "dependencies": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -5061,35 +3785,45 @@
       "integrity": "sha512-82E/lVRaqelV9qmRzzJ1PKTpyrpnT7mwdneKNJB9hUtypZDMggloDfFUCIqRRx3lYRxteCwXSq9c+W71Vf0QnQ=="
     },
     "node_modules/@types/sparqljs": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.3.tgz",
-      "integrity": "sha512-nmFgmR6ns4i8sg9fYu+293H+PMLKmDOZy34sgwgAeUEEiIqSs4guj5aCZRt3gq1g0yuKXkqrxLDq/684g7pGtQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.4.tgz",
+      "integrity": "sha512-0MvCTEfveYJDkI91olLcDf/F3wMMbsxwNxiNZeglt4tbIFULd9pRpcacj1MuA+acFDkTnPXS9L7OqZNn/W1MAg==",
       "dependencies": {
         "rdf-js": "^4.0.2"
       }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
+      "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g=="
     },
     "node_modules/@types/uritemplate": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@types/uritemplate/-/uritemplate-0.3.4.tgz",
       "integrity": "sha512-1D8mJEeQEXynoPQKJkneIK+tXaM2Qnk6c80RBQPV/O2ToypI4mlqXy5jojnYKjTX2Q+EMNMOWt0wNdLbb2MUpA=="
     },
+    "node_modules/@types/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ=="
+    },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
-    "node_modules/@types/xml": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/xml/-/xml-1.0.8.tgz",
-      "integrity": "sha512-IptEZBtDwSPayCP8FmbordhAdjdxsif4zH29xTbBRacZeCHFHZp8OxyG1/CrS8AS0MziJUPTGWCTKbYtvHGYPg==",
+    "node_modules/@types/ws": {
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.17",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
-      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -5207,7 +3941,6 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
       "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -5220,7 +3953,6 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
       "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.46.1",
         "@typescript-eslint/visitor-keys": "5.46.1",
@@ -5273,7 +4005,6 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
       "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.46.1",
         "eslint-visitor-keys": "^3.3.0"
@@ -5287,148 +4018,148 @@
       }
     },
     "node_modules/@webassemblyjs/ast": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
+      "integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
       "peer": true,
       "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+        "@webassemblyjs/helper-numbers": "1.11.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
       }
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
       "peer": true
     },
     "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
       "peer": true
     },
     "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
+      "integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
       "peer": true
     },
     "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
       "peer": true,
       "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.1",
-        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
+        "@webassemblyjs/helper-api-error": "1.11.6",
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
       "peer": true
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
+      "integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
       "peer": true,
       "dependencies": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-buffer": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/wasm-gen": "1.11.1"
+        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/helper-buffer": "1.11.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+        "@webassemblyjs/wasm-gen": "1.11.6"
       }
     },
     "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
       "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "node_modules/@webassemblyjs/leb128": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
       "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
       "peer": true
     },
     "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
+      "integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
       "peer": true,
       "dependencies": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-buffer": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/helper-wasm-section": "1.11.1",
-        "@webassemblyjs/wasm-gen": "1.11.1",
-        "@webassemblyjs/wasm-opt": "1.11.1",
-        "@webassemblyjs/wasm-parser": "1.11.1",
-        "@webassemblyjs/wast-printer": "1.11.1"
+        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/helper-buffer": "1.11.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+        "@webassemblyjs/helper-wasm-section": "1.11.6",
+        "@webassemblyjs/wasm-gen": "1.11.6",
+        "@webassemblyjs/wasm-opt": "1.11.6",
+        "@webassemblyjs/wasm-parser": "1.11.6",
+        "@webassemblyjs/wast-printer": "1.11.6"
       }
     },
     "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
+      "integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
       "peer": true,
       "dependencies": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/ieee754": "1.11.1",
-        "@webassemblyjs/leb128": "1.11.1",
-        "@webassemblyjs/utf8": "1.11.1"
+        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+        "@webassemblyjs/ieee754": "1.11.6",
+        "@webassemblyjs/leb128": "1.11.6",
+        "@webassemblyjs/utf8": "1.11.6"
       }
     },
     "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
+      "integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
       "peer": true,
       "dependencies": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-buffer": "1.11.1",
-        "@webassemblyjs/wasm-gen": "1.11.1",
-        "@webassemblyjs/wasm-parser": "1.11.1"
+        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/helper-buffer": "1.11.6",
+        "@webassemblyjs/wasm-gen": "1.11.6",
+        "@webassemblyjs/wasm-parser": "1.11.6"
       }
     },
     "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
+      "integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
       "peer": true,
       "dependencies": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-api-error": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/ieee754": "1.11.1",
-        "@webassemblyjs/leb128": "1.11.1",
-        "@webassemblyjs/utf8": "1.11.1"
+        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/helper-api-error": "1.11.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+        "@webassemblyjs/ieee754": "1.11.6",
+        "@webassemblyjs/leb128": "1.11.6",
+        "@webassemblyjs/utf8": "1.11.6"
       }
     },
     "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
+      "integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
       "peer": true,
       "dependencies": {
-        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/ast": "1.11.6",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -5445,9 +4176,9 @@
       "peer": true
     },
     "node_modules/@zazuko/rdf-vocabularies": {
-      "version": "2022.11.28",
-      "resolved": "https://registry.npmjs.org/@zazuko/rdf-vocabularies/-/rdf-vocabularies-2022.11.28.tgz",
-      "integrity": "sha512-fg3GwDMI2ooS6VA2C23hFy5BrY5WO4lwjwa0/jYLYUpEHorTk430X0MvKQcfEgyz6U4NO8QDS8jz1CGvC4YLAw==",
+      "version": "2023.1.19",
+      "resolved": "https://registry.npmjs.org/@zazuko/rdf-vocabularies/-/rdf-vocabularies-2023.1.19.tgz",
+      "integrity": "sha512-/vC/Ok8etIi4kflbOAoRr9JV95auJaUREV9lrWP3wDEMfhu8jVYogwi/OD1yA2pH6KIYPS2+z7LN1jxOe3G56g==",
       "dependencies": {
         "@rdfjs/parser-n3": "^1.1.4",
         "commander": "^5.0.0",
@@ -5464,6 +4195,19 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@zazuko/rdf-vocabularies/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
       "engines": {
         "node": ">= 6"
       }
@@ -5604,6 +4348,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -5626,9 +4382,9 @@
       }
     },
     "node_modules/arrayify-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/arrayify-stream/-/arrayify-stream-1.0.0.tgz",
-      "integrity": "sha512-RP80ep76Lbew2wWN5ogrl2NluTnBVYYh2K3NNCcWfcmmUB7nBcNBctiJeEZAixp3I1vQ9H88iHZ9MbHSdkuupQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrayify-stream/-/arrayify-stream-2.0.1.tgz",
+      "integrity": "sha512-z8fB6PtmnewQpFB53piS2d1KlUi3BPMICH2h7leCOUXpQcwvZ4GbHHSpdKoUrgLMR6b4Qan/uDe1St3Ao3yIHg=="
     },
     "node_modules/asn1": {
       "version": "0.2.6",
@@ -5659,15 +4415,20 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
+    "node_modules/async-lock": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
+      "integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ=="
+    },
     "node_modules/asynciterator": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.8.0.tgz",
       "integrity": "sha512-bD34LqKHJnkB77MHjL3hOAUOcy9dbB+3lHvL+EiJpD3k2Nyq3i1dCk5adMisB2rwlrHVu/+XRhOdPZL9hzpsfw=="
     },
     "node_modules/asyncjoin": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.1.1.tgz",
-      "integrity": "sha512-8IqFEIQ3HVec3dLQBvLRx/EFDOof8o+r4nCahRGqGE6WDPTXk7IBEaL6clPZ87DHku7u4yxHGzGWqMN08YwErg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.1.2.tgz",
+      "integrity": "sha512-zi6B+C3GgEu8qrmFn3gDd58cbGNaNFW3s8DJmCxUOjQwqWZcQO6dEoZBWl56+QGQyX0da0FRX1fsAyYB9LmwJA==",
       "dependencies": {
         "asynciterator": "^3.6.0"
       }
@@ -5686,6 +4447,17 @@
       },
       "engines": {
         "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/await-notify": {
@@ -5720,9 +4492,9 @@
       }
     },
     "node_modules/aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -5784,10 +4556,23 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
       "engines": {
         "node": "*"
       }
@@ -5832,7 +4617,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5883,9 +4667,9 @@
       "integrity": "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg=="
     },
     "node_modules/browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.21.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5894,14 +4678,18 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "peer": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001503",
+        "electron-to-chromium": "^1.4.431",
+        "node-releases": "^2.0.12",
+        "update-browserslist-db": "^1.0.11"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5965,10 +4753,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/cache-content-type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
+      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
+      "dependencies": {
+        "mime-types": "^2.1.18",
+        "ylru": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz",
+      "integrity": "sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
     "node_modules/cacheable-request": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -6004,9 +4812,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001439",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
-      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
+      "version": "1.0.30001512",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz",
+      "integrity": "sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==",
       "funding": [
         {
           "type": "opencollective",
@@ -6015,6 +4823,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "peer": true
@@ -6175,9 +4987,9 @@
       }
     },
     "node_modules/clownface-shacl-path": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/clownface-shacl-path/-/clownface-shacl-path-1.4.0.tgz",
-      "integrity": "sha512-87AFtxaJzIYxC+cJ7AsayDRkiubxFrBhSWpxF60d8EFOJU3I8T4c/DpaYjurbebZuxOslHuBPtfZSDJqERLm5g==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/clownface-shacl-path/-/clownface-shacl-path-1.5.1.tgz",
+      "integrity": "sha512-p7mNA/rtl0x6zfIdbbqcwrrgH53dkq3yCAepRH0LMT6ZJTR7zQZ7ggM2ZKcXZWSvH+v2j6MjJjrp8PQpFNX+TA==",
       "dependencies": {
         "@rdf-esm/term-set": "^0.5.0",
         "@tpluscode/rdf-ns-builders": "^2.0.0",
@@ -6187,10 +4999,27 @@
         "clownface": "^1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
     "node_modules/code-block-writer": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
-      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-12.0.0.tgz",
+      "integrity": "sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==",
       "peer": true
     },
     "node_modules/collection-visit": {
@@ -6278,20 +5107,21 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "node_modules/componentsjs": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-4.5.0.tgz",
-      "integrity": "sha512-0F473HDUFfizVXZH1KBP4jmZRBAqYdVdpGhaNmHFmla/AB76B8NN7hQk7YDGaKkESl9zYqQ6kF3i8UgJBQ+rtg==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.4.2.tgz",
+      "integrity": "sha512-qIeXLozDkvubl6qtiovWsIBRqUP80w1ImTbilB6QE3OQgaEExI8pYZ9MkZ10QDFtdoKUryztlqp0AWs49t4puA==",
       "dependencies": {
         "@rdfjs/types": "*",
         "@types/minimist": "^1.2.0",
-        "@types/node": "^14.14.7",
+        "@types/node": "^18.0.0",
         "@types/semver": "^7.3.4",
         "jsonld-context-parser": "^2.1.1",
         "minimist": "^1.2.0",
         "rdf-data-factory": "^1.1.0",
-        "rdf-object": "^1.11.1",
-        "rdf-parse": "^1.9.1",
+        "rdf-object": "^1.14.0",
+        "rdf-parse": "^2.0.0",
         "rdf-quad": "^1.5.0",
+        "rdf-string": "^1.6.0",
         "rdf-terms": "^1.7.0",
         "semver": "^7.3.2",
         "winston": "^3.3.3"
@@ -6304,96 +5134,37 @@
       }
     },
     "node_modules/componentsjs-generator": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/componentsjs-generator/-/componentsjs-generator-2.6.1.tgz",
-      "integrity": "sha512-WA8UNWbBbTmJmC5IxP/N+TJz/XBPfpdzlnzRB5fS2vOmZbwul54/kTxl2V+jjEh/k7Nyh8oKFd/4kE9ZRFSChA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/componentsjs-generator/-/componentsjs-generator-3.1.2.tgz",
+      "integrity": "sha512-0xYgpeH557mFNhwH0LornS5gNlQWrgvXACgvtLzMqDexA5HUY1YcDpTH4nRkfiAuF7Bw8bPDMFyru36lwsKhYA==",
       "dependencies": {
         "@types/lru-cache": "^5.1.0",
         "@types/semver": "^7.3.4",
-        "@typescript-eslint/typescript-estree": "^4.6.1",
+        "@typescript-eslint/typescript-estree": "^5.11.0",
         "comment-parser": "^0.7.6",
-        "componentsjs": "^4.4.0",
-        "jsonld-context-parser": "^2.0.2",
+        "componentsjs": "^5.0.1",
+        "jsonld-context-parser": "^2.1.5",
         "lru-cache": "^6.0.0",
         "minimist": "^1.2.5",
+        "rdf-object": "^1.13.1",
         "semver": "^7.3.2"
       },
       "bin": {
         "componentsjs-generator": "bin/componentsjs-generator.js"
-      }
-    },
-    "node_modules/componentsjs-generator/node_modules/@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/componentsjs-generator/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "node": ">=12.0"
       }
     },
-    "node_modules/componentsjs-generator/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/componentsjs-generator/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/componentsjs/node_modules/@types/node": {
-      "version": "14.18.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
-      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA=="
+    "node_modules/componentsjs-generator/node_modules/@types/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -6426,6 +5197,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookies": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
+      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
@@ -6539,11 +5322,6 @@
         }
       }
     },
-    "node_modules/decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
-    },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
@@ -6552,16 +5330,54 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw=="
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -6591,6 +5407,19 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -6643,24 +5472,16 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/domelementtype": {
@@ -6675,11 +5496,11 @@
       ]
     },
     "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dependencies": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       },
       "engines": {
         "node": ">= 4"
@@ -6689,13 +5510,13 @@
       }
     },
     "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
       "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -6723,10 +5544,24 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
+    "node_modules/ejs": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.284",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+      "version": "1.4.449",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.449.tgz",
+      "integrity": "sha512-TxLRpRUj/107ATefeP8VIUWNOv90xJxZZbCW/eIbSZQiuiFANCx2b7u+GbVc9X4gU+xnbvypNMYVM/WArE1DNQ==",
       "peer": true
     },
     "node_modules/emoji-regex": {
@@ -6777,9 +5612,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "engines": {
         "node": ">=0.12"
       },
@@ -6799,35 +5634,44 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
+        "string.prototype.trim": "^1.2.7",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
-        "unbox-primitive": "^1.0.2"
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6837,10 +5681,23 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
+      "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
       "peer": true
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
@@ -7011,7 +5868,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -7625,9 +6481,9 @@
       }
     },
     "node_modules/fetch-sparql-endpoint": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-2.4.1.tgz",
-      "integrity": "sha512-4tDjPaRM3NH7CZ7ovLpFpyGQMtOH3L6LO/mbGT8ekHKvZyuXIkrykPTDmb0aEM13Wh1X1SzmQC22yqD8ORKe3w==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-3.3.3.tgz",
+      "integrity": "sha512-5ZNesFhFMcsEiSaCyg36L5VU7YP7xMJogc5i0n00nFNFZzrfGJ4Cm8LGrzXI6eySkb7QmaRyNWJGk5btAOjniA==",
       "dependencies": {
         "@rdfjs/types": "*",
         "@types/readable-stream": "^2.3.11",
@@ -7640,8 +6496,8 @@
         "rdf-string": "^1.6.0",
         "readable-web-to-node-stream": "^3.0.2",
         "sparqljs": "^3.1.2",
-        "sparqljson-parse": "^1.7.0",
-        "sparqlxml-parse": "^1.5.0",
+        "sparqljson-parse": "^2.2.0",
+        "sparqlxml-parse": "^2.1.1",
         "stream-to-string": "^1.1.0"
       },
       "bin": {
@@ -7658,6 +6514,33 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -7781,6 +6664,14 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -7856,6 +6747,19 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -7895,12 +6799,13 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       },
       "funding": {
@@ -8005,6 +6910,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -8035,10 +6954,42 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/got/node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -8054,68 +7005,48 @@
         "node": ">= 10.x"
       }
     },
-    "node_modules/graphql-ld": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/graphql-ld/-/graphql-ld-1.4.1.tgz",
-      "integrity": "sha512-oJ8o/1DdAbM+oNE9FBnc0bbWgzvImnl/o2fty2NzA4nyj4T6HNbAkr1CcUL9OieSZPEAW7QcU7W66OVHkxDwVw==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "graphql-to-sparql": "^2.4.0",
-        "jsonld-context-parser": "^2.1.0",
-        "sparqlalgebrajs": "^3.0.2",
-        "sparqljson-to-tree": "^2.1.0"
-      }
-    },
-    "node_modules/graphql-ld/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
     "node_modules/graphql-to-sparql": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-2.4.0.tgz",
-      "integrity": "sha512-AwfWSV8NUe5aY2QR+NzUUxImbe8GrUR12PvYBHq6r62aj66667yLdI5xOPsVGcS0DsQJN8+9CXC+vhkjc8mR9Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-3.0.1.tgz",
+      "integrity": "sha512-A+RwB99o66CUj+XuqtP/u3P7fGS/qF6P+/jhNl1BE/JZ2SCnkrODvV0LADuJeCDmPh45fDhq+GTDVoN1ZQHYFw==",
       "dependencies": {
         "@rdfjs/types": "*",
-        "graphql": "^15.0.0",
+        "graphql": "^15.5.2",
         "jsonld-context-parser": "^2.0.2",
         "minimist": "^1.2.0",
         "rdf-data-factory": "^1.1.0",
-        "sparqlalgebrajs": "^3.0.2"
+        "sparqlalgebrajs": "^4.0.0"
       },
       "bin": {
         "graphql-to-sparql": "bin/graphql-to-sparql.js"
       }
     },
-    "node_modules/graphql-to-sparql/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
         "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
       },
       "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/har-schema": {
@@ -8172,6 +7103,17 @@
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
       "dependencies": {
         "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8248,9 +7190,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+      "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -8259,16 +7201,59 @@
         }
       ],
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.2",
-        "domutils": "^2.8.0",
-        "entities": "^3.0.1"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -8305,6 +7290,18 @@
       "engines": {
         "node": ">=0.8",
         "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -8346,12 +7343,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -8394,16 +7388,39 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "dependencies": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/ipaddr.js": {
@@ -8423,6 +7440,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-arrayish": {
@@ -8535,6 +7565,20 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -8680,6 +7724,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -8715,6 +7777,11 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/iso8601-duration": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/iso8601-duration/-/iso8601-duration-2.1.1.tgz",
+      "integrity": "sha512-VGGpW30/R57FpG1J7RqqKBAaK7lIiudlZkQ5tRoO9hNlKYQNnhs60DQpXlPFBmp6I+kJ61PHkI3f/T7cR4wfbw=="
+    },
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -8727,6 +7794,87 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+    },
+    "node_modules/jake": {
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jake/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jake/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jake/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jake/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/jake/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jake/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -8767,9 +7915,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.1.tgz",
-      "integrity": "sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q==",
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+      "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -8806,6 +7954,17 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
+    "node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -8839,9 +7998,9 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -8875,9 +8034,9 @@
       }
     },
     "node_modules/jsonld-context-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.2.2.tgz",
-      "integrity": "sha512-3VWIg/4NCMTXP6NsI6O93spFTd4qIOucKEmD8I+Exhxk9ZUVrnkLp2G4f0toR5jVleZkiiB9YGPS+yT1wwMqnQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.3.0.tgz",
+      "integrity": "sha512-c6w2GE57O26eWFjcPX6k6G86ootsIfpuVwhZKjCll0bVoDGBxr1P4OuU+yvgfnh1GJhAGErolfC7W1BklLjWMg==",
       "dependencies": {
         "@types/http-link-header": "^1.0.1",
         "@types/node": "^18.0.0",
@@ -8891,49 +8050,32 @@
       }
     },
     "node_modules/jsonld-streaming-parser": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.4.3.tgz",
-      "integrity": "sha512-ysuevJ+l8+Y4W3J/yQW3pa9VCBNDHo2tZkKmPAnfhfsmFMyxuueAeXMmTbpJZdrpagzeeDVr3A8EZVuHliQJ9A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.2.0.tgz",
+      "integrity": "sha512-lJR1SCT364PGpFrOQaY+ZQ7qDWqqiT3IMK+AvZ83fo0LvltFn8/UyXvIFc3RO7YcaEjLahAF0otCi8vOq21NtQ==",
       "dependencies": {
+        "@bergos/jsonparse": "^1.4.0",
         "@rdfjs/types": "*",
         "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
         "canonicalize": "^1.0.1",
         "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.1.3",
-        "jsonparse": "^1.3.1",
-        "rdf-data-factory": "^1.1.0"
+        "jsonld-context-parser": "^2.3.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
       }
     },
     "node_modules/jsonld-streaming-serializer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-1.3.0.tgz",
-      "integrity": "sha512-QGflpxpwmr659ExvAQ5TFAY9BmJQiL/yF/MDRrP5oVWHcBBLhbPjUqDv//y2OvJxUY3UQYMXulTwzmYb1ttv2Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-2.1.0.tgz",
+      "integrity": "sha512-COHdLoeMTnrqHMoFhN3PoAwqnrKrpPC7/ACb0WbELYvt+HSOIFN3v4IJP7fOtLNQ4GeaeYkvbeWJ7Jo4EjxMDw==",
       "dependencies": {
         "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.0.0"
-      }
-    },
-    "node_modules/jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
-      "engines": [
-        "node >= 0.2.0"
-      ]
-    },
-    "node_modules/JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dependencies": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      },
-      "bin": {
-        "JSONStream": "bin.js"
-      },
-      "engines": {
-        "node": "*"
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "jsonld-context-parser": "^2.0.0",
+        "readable-stream": "^4.0.0"
       }
     },
     "node_modules/jsprim": {
@@ -8950,6 +8092,17 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
@@ -8964,6 +8117,87 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/koa": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.14.2.tgz",
+      "integrity": "sha512-VFI2bpJaodz6P7x2uyLiX6RLYpZmOJqNmoCst/Yyd7hQlszyPwG/I9CQJ63nOtKSxpt5M7NH67V6nJL2BwCl7g==",
+      "dependencies": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.8.0",
+        "debug": "^4.3.2",
+        "delegates": "^1.0.0",
+        "depd": "^2.0.0",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^2.0.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
+    },
+    "node_modules/koa-convert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
+      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
+      "dependencies": {
+        "co": "^4.6.0",
+        "koa-compose": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/koa/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/kuler": {
@@ -9081,11 +8315,26 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.orderby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.orderby/-/lodash.orderby-4.6.0.tgz",
+      "integrity": "sha512-T0rZxKmghOOf5YPnn8EY5iLYeWCpZq8G41FfqoVHH5QDTAFaghJRmAdLiadEDq+ztgM2q5PjA+Z1fOwGrLgmtg=="
     },
     "node_modules/log-symbols": {
       "version": "2.2.0",
@@ -9099,11 +8348,12 @@
       }
     },
     "node_modules/logform": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.2.tgz",
-      "integrity": "sha512-W4c9himeAwXEdZ05dQNerhFz2XG80P9Oj0loPUMV23VC2it0orMHQhJm4hdnnor3rd1HsGf6a2lPwBM1zeXHGw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.5.1.tgz",
+      "integrity": "sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==",
       "dependencies": {
         "@colors/colors": "1.5.0",
+        "@types/triple-beam": "^1.3.2",
         "fecha": "^4.2.0",
         "ms": "^2.1.1",
         "safe-stable-stringify": "^2.3.1",
@@ -9183,6 +8433,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -9204,9 +8465,9 @@
       }
     },
     "node_modules/memory-fs/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -9258,28 +8519,21 @@
       }
     },
     "node_modules/microdata-rdf-streaming-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-1.2.0.tgz",
-      "integrity": "sha512-cMLNLEcS0mPaiA9iwq6BnsQK9sx2uBwjpRZIEvMRBNJpbvV58f8AFtPeYzNFh3OPyX9B49NYJ77bB0jNAUCurw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-2.0.1.tgz",
+      "integrity": "sha512-oEEYP3OwPGOtoE4eIyJvX1eJXI7VkGR4gKYqpEufaRXc2ele/Tkid/KMU3Los13wGrOq6woSxLEGOYSHzpRvwA==",
       "dependencies": {
         "@rdfjs/types": "*",
-        "htmlparser2": "^6.0.0",
+        "htmlparser2": "^8.0.0",
         "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.1.0",
         "relative-to-absolute-iri": "^1.0.2"
       }
     },
-    "node_modules/microdata-rdf-streaming-parser/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/microdata-rdf-streaming-parser/node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -9288,10 +8542,10 @@
         }
       ],
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/micromatch": {
@@ -9364,7 +8618,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -9373,9 +8626,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -9417,9 +8670,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/n3": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.3.tgz",
-      "integrity": "sha512-9caLSZuMW1kdlPxEN4ka6E4E8a5QKoZ2emxpW+zHMofI+Bo92nJhN//wNub15S5T9I4c6saEqdGEu+YXJqMZVA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.17.0.tgz",
+      "integrity": "sha512-dYdkyUM4tMWHSEf9xMDPiBjOJc+rcjZHtN5cJJGcvAwOWTjE9u1i28sDFWALTwyROvsuUKuLohrz7VFaJbhiDw==",
       "dependencies": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^4.0.0"
@@ -9428,18 +8681,21 @@
         "node": ">=12.0"
       }
     },
-    "node_modules/n3/node_modules/readable-stream": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/nanomatch": {
@@ -9491,8 +8747,7 @@
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "peer": true
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next-tick": {
       "version": "1.1.0",
@@ -9519,10 +8774,18 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
       "peer": true
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.3.tgz",
+      "integrity": "sha512-fy9v3NgTzBngrMFkDsKEj0r02U7jm6XfC3b52eoNV+GCrGj+s8pt5OqhiJdWKuw51zCTdiNR/IUD1z33LIIGpg==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-url": {
       "version": "6.1.0",
@@ -9638,9 +8901,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -9708,6 +8971,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oidc-provider": {
+      "version": "7.10.6",
+      "resolved": "https://registry.npmjs.org/oidc-provider/-/oidc-provider-7.10.6.tgz",
+      "integrity": "sha512-7fbnormUyTLP34dmR5WXoJtTWtfj6MsFNzIMKVRKv21e18NIXggn14EBUFC5rrMMtmeExb03+lJI/v+opD+0oQ==",
+      "dependencies": {
+        "@koa/cors": "^3.1.0",
+        "cacheable-lookup": "^6.0.1",
+        "debug": "^4.3.2",
+        "ejs": "^3.1.6",
+        "got": "^11.8.2",
+        "jose": "^4.1.4",
+        "jsesc": "^3.0.2",
+        "koa": "^2.13.3",
+        "koa-compose": "^4.1.0",
+        "nanoid": "^3.1.28",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.1",
+        "paseto2": "npm:paseto@^2.1.3",
+        "quick-lru": "^5.1.1",
+        "raw-body": "^2.4.1"
+      },
+      "engines": {
+        "node": "^12.19.0 || ^14.15.0 || ^16.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      },
+      "optionalDependencies": {
+        "paseto3": "npm:paseto@^3.0.0"
+      }
+    },
     "node_modules/oidc-token-hash": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
@@ -9743,6 +9037,11 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ=="
+    },
     "node_modules/openid-client": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.3.1.tgz",
@@ -9772,6 +9071,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -9815,9 +9122,9 @@
       }
     },
     "node_modules/parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha512-Z0gpfHmwCIKDr5rRzjypL+p93aHVWO7e+0rFcUl9E3sC67njjs+xHFenuboSXZGlvYtmQqRzRaE3iFpTUnLmFQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
       "dependencies": {
         "xtend": "~4.0.1"
       }
@@ -9836,6 +9143,31 @@
       "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/paseto2": {
+      "name": "paseto",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/paseto/-/paseto-2.1.3.tgz",
+      "integrity": "sha512-BNkbvr0ZFDbh3oV13QzT5jXIu8xpFc9r0o5mvWBhDU1GBkVt1IzHK1N6dcYmN7XImrUmPQ0HCUXmoe2WPo8xsg==",
+      "engines": {
+        "node": "^12.19.0 || >=14.15.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/paseto3": {
+      "name": "paseto",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/paseto/-/paseto-3.1.4.tgz",
+      "integrity": "sha512-BifaKKu+MS9b/vTgFMC6Q8uLUMqw8VtYgl4qODJWb6Jqt+dTKn8XH9EftJZx+6wxF4ELBbKdH33DZa4inMYVcg==",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/path-browserify": {
@@ -9951,6 +9283,16 @@
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
       "integrity": "sha512-7rrONfyLkDEc7OJ5QBkqa4KI4EBhCd340xRuIUPGCfu13znS+vx+VDdrT9ODAJHlXm7w4lbxN3DRjyv58EuzDg=="
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -10023,6 +9365,17 @@
         }
       ]
     },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -10065,198 +9418,51 @@
       }
     },
     "node_modules/rdf-data-factory": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.1.tgz",
-      "integrity": "sha512-0HoLx7lbBlNd2YTmNKin0txgiYmAV56eVU823at8cG2+iD0Ia5kcRNDpzZy6I/HCtFTymHvTfdhHTzm3ak3Jpw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
+      "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
       "dependencies": {
         "@rdfjs/types": "*"
       }
     },
     "node_modules/rdf-dereference": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/rdf-dereference/-/rdf-dereference-1.9.0.tgz",
-      "integrity": "sha512-nRpESjNKoUugzqMyM/perJXZpKIR+Ac6yhkDzq+Zcjc9lQte5ptz+I7EQn0+2DbZwLvKlb/P/FXI+wTBMpGBAA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-dereference/-/rdf-dereference-2.1.0.tgz",
+      "integrity": "sha512-1ZUgruR9mkFC+sbn8qWTDVEL+NgU6MUS4Fp4c0ykZFPizopwvtBqr2Z8IJr579HGFY7HBZIfgljNXMqFls+PHQ==",
       "dependencies": {
-        "@comunica/actor-http-node-fetch": "~1.22.0",
-        "@comunica/actor-http-proxy": "~1.22.0",
-        "@comunica/actor-rdf-dereference-file": "~1.22.0",
-        "@comunica/actor-rdf-dereference-http-parse": "~1.22.0",
-        "@comunica/actor-rdf-parse-html": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-microdata": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-rdfa": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-script": "~1.22.0",
-        "@comunica/actor-rdf-parse-jsonld": "~1.22.0",
-        "@comunica/actor-rdf-parse-n3": "~1.22.0",
-        "@comunica/actor-rdf-parse-rdfxml": "~1.22.0",
-        "@comunica/actor-rdf-parse-xml-rdfa": "~1.22.0",
-        "@comunica/bus-http": "~1.22.0",
-        "@comunica/bus-init": "~1.22.0",
-        "@comunica/bus-rdf-dereference": "~1.22.0",
-        "@comunica/bus-rdf-parse": "~1.22.0",
-        "@comunica/bus-rdf-parse-html": "~1.22.0",
-        "@comunica/core": "~1.22.0",
-        "@comunica/mediator-combine-union": "~1.22.0",
-        "@comunica/mediator-number": "~1.22.0",
-        "@comunica/mediator-race": "~1.22.0",
+        "@comunica/actor-dereference-fallback": "^2.0.2",
+        "@comunica/actor-dereference-file": "^2.0.2",
+        "@comunica/actor-dereference-http": "^2.0.2",
+        "@comunica/actor-dereference-rdf-parse": "^2.6.0",
+        "@comunica/actor-http-fetch": "^2.0.1",
+        "@comunica/actor-http-proxy": "^2.0.1",
+        "@comunica/actor-rdf-parse-html": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-parse-n3": "^2.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
+        "@comunica/actor-rdf-parse-shaclc": "^2.6.0",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
+        "@comunica/bus-dereference": "^2.0.2",
+        "@comunica/bus-dereference-rdf": "^2.0.2",
+        "@comunica/bus-http": "^2.0.1",
+        "@comunica/bus-init": "^2.0.1",
+        "@comunica/bus-rdf-parse": "^2.0.1",
+        "@comunica/bus-rdf-parse-html": "^2.0.1",
+        "@comunica/config-query-sparql": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/mediator-combine-pipeline": "^2.0.1",
+        "@comunica/mediator-combine-union": "^2.0.1",
+        "@comunica/mediator-number": "^2.0.1",
+        "@comunica/mediator-race": "^2.0.1",
         "@rdfjs/types": "*",
         "rdf-string": "^1.6.0",
         "stream-to-string": "^1.2.0"
       },
       "bin": {
         "rdf-dereference": "bin/Runner.js"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/actor-http-node-fetch": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-node-fetch/-/actor-http-node-fetch-1.22.3.tgz",
-      "integrity": "sha512-e2J8g32QgwcbysOQkFDio757oaPLCGpSs7rRDoGq/daGS8l1m7Ugzhx7Vh3NHcCI3XXrymMOBzMT+ku5ddJbNg==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "cross-fetch": "^3.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/actor-http-proxy": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.22.1.tgz",
-      "integrity": "sha512-q8Dil+MnKeZWKNxLLDXan070TUP+8io7zwwCs5apvaU26ghojBU4OOJx1vL6CInUjZCzTeyCYVPsBbvykjLZ2w==",
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.8.0",
-        "@comunica/context-entries": "^1.0.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.22.3.tgz",
-      "integrity": "sha512-OBtJTHA8OXAWF3+FJ7n0R1i8nGzxD2xK18mgMPu4JId9r9bUS4RMKCDWa8MIG6p9Hd7SleuS9bC48w5vm07yww==",
-      "dependencies": {
-        "cross-fetch": "^3.0.5",
-        "relative-to-absolute-iri": "^1.0.5",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-dereference": "^1.0.0",
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.22.1.tgz",
-      "integrity": "sha512-MFFhJ6eGyO40Be80zsFKAbRjkPXr80PvCqvVKsEstdv3u9C6GFV3nqZpCwvsVCz22IPQhW+rzb8ZyasmgHnurA==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.1.2",
-        "jsonld-streaming-parser": "^2.4.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/actor-rdf-parse-n3": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.22.0.tgz",
-      "integrity": "sha512-qHrGfh5k/pZa4imy7m9gJ1kt9aW1uxXqLDKnLKvR2l0m09YiEx/YOYWr1Wtu1YtH/Yyc13OX4mo/OwaE5PfrHQ==",
-      "dependencies": {
-        "@types/n3": "^1.4.4",
-        "n3": "^1.6.3"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/bus-http": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.22.1.tgz",
-      "integrity": "sha512-CZ0NDWZH0k0FOshuRQJzYr3Z+2ZM1vqr9ZepONuaoYDwyKaxl29xPs3hNfjSy6YawjEQP+elr/WDc3TxKIpu8g==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/readable-stream": "^2.3.11",
-        "is-stream": "^2.0.0",
-        "readable-web-to-node-stream": "^3.0.2",
-        "web-streams-node": "^0.4.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/bus-init": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.22.0.tgz",
-      "integrity": "sha512-NIfEJLI8EYFdTWJB0PV/lxPagStPl+gUj3LtOnovcF1ZhC5rgcJSC/tq1r04n0TziY2KVangnLDsF4752LjD6g==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/bus-rdf-dereference": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.22.2.tgz",
-      "integrity": "sha512-dtLEmCzlscpe8AqEver8H+7a7UzyOXslUQ00VE+igt/+oAQvJpRBCQ3yB6XkyjAV/+ApLrbAjpCRf3Gp2NWfgg==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/bus-rdf-parse": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.22.0.tgz",
-      "integrity": "sha512-ohZGlabX5K+dEmn+v4BzP+IZVyRc1ovWItHDLznnRqsHQr8W19WPG21lEFh5kk2MK4YnyQWmlUax1Yxrg7cbXg==",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/core": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.22.0.tgz",
-      "integrity": "sha512-tgozygRFTd6t6l0YyvfVUWNC+KXWiTlBclkxtzFioQsplKvUSvg1TPjopRk8hhAvMaNRGMNBK2ZafNaqNTkI4w==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "immutable": "^3.8.2"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/mediator-combine-union": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.22.0.tgz",
-      "integrity": "sha512-iUHmEGgWVmk02e80uB7w8xZ5vgTLpiqzrImvbokolJzWcVbobVCUkq8DUxzz3FJbNVRGipZUFrOqkRPAuAX6FA==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/mediator-number": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.22.0.tgz",
-      "integrity": "sha512-KDPlJEvj0Lu+JygGXjnH8pf33k01lJ+wgzUlWK216jZJ1Px2lTlfc/COhSqi/e0y+k4ZSBcxx0gnjt2awMpbrQ==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-dereference/node_modules/@comunica/mediator-race": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.22.0.tgz",
-      "integrity": "sha512-hIMaHyf9M4jOS0199OURSVgWFmzkyF2K2keuAb+iHoCH3UUcUnWjPOL1TrdkxvaUnrxmsBWR9SXbnqgMnhIsiQ==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
       }
     },
     "node_modules/rdf-ext": {
@@ -10271,12 +9477,17 @@
         "readable-stream": "^3.6.0"
       }
     },
-    "node_modules/rdf-ext/node_modules/@rdfjs/to-ntriples": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz",
-      "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA==",
+    "node_modules/rdf-ext/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
       "engines": {
-        "node": ">=6"
+        "node": ">= 6"
       }
     },
     "node_modules/rdf-isomorphic": {
@@ -10313,9 +9524,9 @@
       "integrity": "sha512-1ocjoxovKc4+AyS4Tgtroay5R33yrtM2kQnAGvVaB0iGSRggukHxMJW0y8xTR7TwKZabS+7oMSQNMdbu/qTtCQ=="
     },
     "node_modules/rdf-object": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.13.2.tgz",
-      "integrity": "sha512-DVLDCbxPOkhd/k43j9wcLU7CXe/gdldBBomMV3RyZ1G9E2zPa2FFNFijzMGgRGNY1OEyGmhBxw2eiJjUC7GVNw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.14.0.tgz",
+      "integrity": "sha512-/KSUWr7onDtL7d81kOpcUzJ2vHYOYJc2KU9WzBZRYydBhK0Sksh5Hg4VCQNaxUEvYEgdrrTuq9SLpOOCmag0rQ==",
       "dependencies": {
         "@rdfjs/types": "*",
         "jsonld-context-parser": "^2.0.2",
@@ -10325,131 +9536,34 @@
       }
     },
     "node_modules/rdf-parse": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-1.9.1.tgz",
-      "integrity": "sha512-W6ouYE+ufmCNFmXD1iGs5gUZH75jZekh/I5qF8a4Sl37BUc9mY0Jz5A0CV1tiKKhx+I+HYfxyX9VjOljD8rzgQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.3.2.tgz",
+      "integrity": "sha512-TOeI7FKlyr/GupfGaXZvpMLzvByOrtwt4zHLMuuy3deNGse9QyhHsspVraZam491sIgBogdchzcUqkf2WXnAsg==",
       "dependencies": {
-        "@comunica/actor-http-native": "~1.22.0",
-        "@comunica/actor-rdf-parse-html": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-microdata": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-rdfa": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-script": "~1.22.0",
-        "@comunica/actor-rdf-parse-jsonld": "^1.22.0",
-        "@comunica/actor-rdf-parse-n3": "~1.22.0",
-        "@comunica/actor-rdf-parse-rdfxml": "~1.22.0",
-        "@comunica/actor-rdf-parse-xml-rdfa": "~1.22.0",
-        "@comunica/bus-http": "~1.22.0",
-        "@comunica/bus-init": "~1.22.0",
-        "@comunica/bus-rdf-parse": "~1.22.0",
-        "@comunica/bus-rdf-parse-html": "~1.22.0",
-        "@comunica/core": "~1.22.0",
-        "@comunica/mediator-combine-union": "~1.22.0",
-        "@comunica/mediator-number": "~1.22.0",
-        "@comunica/mediator-race": "~1.22.0",
+        "@comunica/actor-http-fetch": "^2.0.1",
+        "@comunica/actor-http-proxy": "^2.0.1",
+        "@comunica/actor-rdf-parse-html": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-parse-n3": "^2.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
+        "@comunica/actor-rdf-parse-shaclc": "^2.6.2",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
+        "@comunica/bus-http": "^2.0.1",
+        "@comunica/bus-init": "^2.0.1",
+        "@comunica/bus-rdf-parse": "^2.0.1",
+        "@comunica/bus-rdf-parse-html": "^2.0.1",
+        "@comunica/config-query-sparql": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/mediator-combine-pipeline": "^2.0.1",
+        "@comunica/mediator-combine-union": "^2.0.1",
+        "@comunica/mediator-number": "^2.0.1",
+        "@comunica/mediator-race": "^2.0.1",
         "@rdfjs/types": "*",
+        "readable-stream": "^4.3.0",
         "stream-to-string": "^1.2.0"
-      }
-    },
-    "node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.22.1.tgz",
-      "integrity": "sha512-MFFhJ6eGyO40Be80zsFKAbRjkPXr80PvCqvVKsEstdv3u9C6GFV3nqZpCwvsVCz22IPQhW+rzb8ZyasmgHnurA==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.1.2",
-        "jsonld-streaming-parser": "^2.4.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-n3": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.22.0.tgz",
-      "integrity": "sha512-qHrGfh5k/pZa4imy7m9gJ1kt9aW1uxXqLDKnLKvR2l0m09YiEx/YOYWr1Wtu1YtH/Yyc13OX4mo/OwaE5PfrHQ==",
-      "dependencies": {
-        "@types/n3": "^1.4.4",
-        "n3": "^1.6.3"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-parse/node_modules/@comunica/bus-http": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.22.1.tgz",
-      "integrity": "sha512-CZ0NDWZH0k0FOshuRQJzYr3Z+2ZM1vqr9ZepONuaoYDwyKaxl29xPs3hNfjSy6YawjEQP+elr/WDc3TxKIpu8g==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/readable-stream": "^2.3.11",
-        "is-stream": "^2.0.0",
-        "readable-web-to-node-stream": "^3.0.2",
-        "web-streams-node": "^0.4.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-parse/node_modules/@comunica/bus-init": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.22.0.tgz",
-      "integrity": "sha512-NIfEJLI8EYFdTWJB0PV/lxPagStPl+gUj3LtOnovcF1ZhC5rgcJSC/tq1r04n0TziY2KVangnLDsF4752LjD6g==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-parse/node_modules/@comunica/bus-rdf-parse": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.22.0.tgz",
-      "integrity": "sha512-ohZGlabX5K+dEmn+v4BzP+IZVyRc1ovWItHDLznnRqsHQr8W19WPG21lEFh5kk2MK4YnyQWmlUax1Yxrg7cbXg==",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-parse/node_modules/@comunica/core": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.22.0.tgz",
-      "integrity": "sha512-tgozygRFTd6t6l0YyvfVUWNC+KXWiTlBclkxtzFioQsplKvUSvg1TPjopRk8hhAvMaNRGMNBK2ZafNaqNTkI4w==",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "immutable": "^3.8.2"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/rdf-parse/node_modules/@comunica/mediator-combine-union": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.22.0.tgz",
-      "integrity": "sha512-iUHmEGgWVmk02e80uB7w8xZ5vgTLpiqzrImvbokolJzWcVbobVCUkq8DUxzz3FJbNVRGipZUFrOqkRPAuAX6FA==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-parse/node_modules/@comunica/mediator-number": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.22.0.tgz",
-      "integrity": "sha512-KDPlJEvj0Lu+JygGXjnH8pf33k01lJ+wgzUlWK216jZJ1Px2lTlfc/COhSqi/e0y+k4ZSBcxx0gnjt2awMpbrQ==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-parse/node_modules/@comunica/mediator-race": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.22.0.tgz",
-      "integrity": "sha512-hIMaHyf9M4jOS0199OURSVgWFmzkyF2K2keuAb+iHoCH3UUcUnWjPOL1TrdkxvaUnrxmsBWR9SXbnqgMnhIsiQ==",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
       }
     },
     "node_modules/rdf-quad": {
@@ -10463,12 +9577,13 @@
       }
     },
     "node_modules/rdf-serialize": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rdf-serialize/-/rdf-serialize-2.0.1.tgz",
-      "integrity": "sha512-GjFSp0Nzh4wxs6lpmdTQQBpjKYl8Lt89dR6PYuLp/YkliByR9tf6c+v4O1srFlfeCZ1u6xMarP0V3/CTMPqy8g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rdf-serialize/-/rdf-serialize-2.2.2.tgz",
+      "integrity": "sha512-zzWQMMMmDzocuFLEOcdz8U5AxbdjBvknwFEHXCyw2lklcEjd2OtsvD5NgWQc+zbsWZKxewvDYEXuzhkNAHRv1g==",
       "dependencies": {
-        "@comunica/actor-rdf-serialize-jsonld": "^2.0.1",
-        "@comunica/actor-rdf-serialize-n3": "^2.0.1",
+        "@comunica/actor-rdf-serialize-jsonld": "^2.6.6",
+        "@comunica/actor-rdf-serialize-n3": "^2.6.6",
+        "@comunica/actor-rdf-serialize-shaclc": "^2.6.0",
         "@comunica/bus-init": "^2.0.1",
         "@comunica/bus-rdf-serialize": "^2.0.1",
         "@comunica/config-query-sparql": "^2.0.1",
@@ -10477,152 +9592,8 @@
         "@comunica/mediator-combine-union": "^2.0.1",
         "@comunica/mediator-race": "^2.0.1",
         "@rdfjs/types": "*",
-        "stream-to-string": "^1.2.0"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/@comunica/actor-abstract-mediatyped": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.5.1.tgz",
-      "integrity": "sha512-Iz8j1XqXp/A7HJVDTtEtp7hV6nuNoIjjEUgiJUiBTM5OIx7sFbGfUd10VtHPSXB/3lHHcIo34BKNZkeurNo6BA==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/@comunica/actor-rdf-serialize-jsonld": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.5.1.tgz",
-      "integrity": "sha512-QYyruMJBKYeIeTENMsBfCq3/fRUTlmMtOchRn0Hf8vWp+ZO5sx7EksvwA3hEJ0yzbHaNSOoi53I5CcJYNMG2yA==",
-      "dependencies": {
-        "@comunica/bus-rdf-serialize": "^2.5.1",
-        "@comunica/types": "^2.5.1",
-        "jsonld-streaming-serializer": "^2.0.1"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/@comunica/actor-rdf-serialize-n3": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.5.1.tgz",
-      "integrity": "sha512-llK3kiNtqrEBTL5z8GIDM/SjT9nv41Pugm+H/j+hTjNIVfSCHpaobUuQdft7TDVYeXu6/U18lXcz8n1bAspKfA==",
-      "dependencies": {
-        "@comunica/bus-rdf-serialize": "^2.5.1",
-        "@comunica/types": "^2.5.1",
-        "n3": "^1.16.3"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/@comunica/bus-init": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.5.1.tgz",
-      "integrity": "sha512-TDakSkGzM+3xkZ+xBCBmzWNagmDWUc+F6TPYOFO8goaT1+tVrPh9wPD5t2n1zkKMzG2dOVT4O8jxUfCyzmNwKA==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "readable-stream": "^4.2.0"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/@comunica/bus-rdf-serialize": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.5.1.tgz",
-      "integrity": "sha512-GMg3dkWrFSYzxsp8hDNSgpWKyInDQ78lmy9TqVUo+EIgvIDhMXZJqsJmQNf/frcMYlPqdr1CwGnRxp+Jf7li+g==",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^2.5.1",
-        "@comunica/core": "^2.5.1",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/@comunica/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-      "dependencies": {
-        "@comunica/types": "^2.5.1",
-        "immutable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/@comunica/mediator-combine-pipeline": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.5.1.tgz",
-      "integrity": "sha512-vsi6YA7NGPQoNSPtKHWUbsDK+678w0BdE9DEzLWOa2pqiWoeT4SuJV4szHQNVuJjzi6j6VTXuR58mZL7XqreTw==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/@comunica/mediator-combine-union": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.5.1.tgz",
-      "integrity": "sha512-vpbQn3xtoX+F00xv+AKbn+qUe66rIiycbiZoE/s/qtlmUbVKLItEMMuToDGRdcdC9mtPiieIrgremXd/RVdHTw==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/@comunica/mediator-race": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.5.1.tgz",
-      "integrity": "sha512-VuHHZSDagK9k85NBTEvbbhkb/Xd9zgt9jBlYIVRarushJ8ihqfs8dXQ2Hs0gdOTyrCMFiQIimbN1h58QcmmKyg==",
-      "dependencies": {
-        "@comunica/core": "^2.5.1"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/@comunica/types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-      "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.13",
-        "asynciterator": "^3.8.0",
-        "sparqlalgebrajs": "^4.0.5"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-    },
-    "node_modules/rdf-serialize/node_modules/jsonld-streaming-serializer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-2.1.0.tgz",
-      "integrity": "sha512-COHdLoeMTnrqHMoFhN3PoAwqnrKrpPC7/ACb0WbELYvt+HSOIFN3v4IJP7fOtLNQ4GeaeYkvbeWJ7Jo4EjxMDw==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/readable-stream": "^2.3.13",
-        "buffer": "^6.0.3",
-        "jsonld-context-parser": "^2.0.0",
-        "readable-stream": "^4.0.0"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/readable-stream": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/rdf-serialize/node_modules/sparqlalgebrajs": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-      "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.3",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.6",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.6.1"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+        "readable-stream": "^4.3.0",
+        "stream-to-string": "^1.1.0"
       }
     },
     "node_modules/rdf-store-stream": {
@@ -10634,10 +9605,36 @@
         "n3": "^1.11.1"
       }
     },
+    "node_modules/rdf-stores": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-stores/-/rdf-stores-1.0.0.tgz",
+      "integrity": "sha512-wqp7M5409rbhpWQE0C1vyVysbz++aD2vEkZ6yueSxhDtyLvznS41R3cKiuUpm3ikc/yTpaCZwPo4iyKEaAwBIg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.2",
+        "rdf-terms": "^1.9.1"
+      }
+    },
+    "node_modules/rdf-streaming-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-streaming-store/-/rdf-streaming-store-1.1.0.tgz",
+      "integrity": "sha512-C/5NTKGpKrNJ5VUo42DtGFsXYDlP3rx/u4C6gEBuSn+6eVFahjFdUDgNGcPtVyhCQkctRCj3GT1lX9UeyoXWtw==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/n3": "^1.10.4",
+        "@types/readable-stream": "^2.3.15",
+        "n3": "^1.16.3",
+        "rdf-string": "^1.6.2",
+        "rdf-terms": "^1.9.1",
+        "readable-stream": "^4.3.0"
+      }
+    },
     "node_modules/rdf-string": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.2.tgz",
-      "integrity": "sha512-tr0aStKYRmT6ShmGsA4HikIn6O3ZkCBSLWsRbeKhlPVPZodl0QNuws6HuJdD1rUyo9+MNiDw+3wvFSUz6Iwv/g==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
+      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
       "dependencies": {
         "@rdfjs/types": "*",
         "rdf-data-factory": "^1.1.0"
@@ -10653,38 +9650,62 @@
       }
     },
     "node_modules/rdf-terms": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.9.1.tgz",
-      "integrity": "sha512-GrE8CbQSvuVEFRCywMu6VOgV1AFE6X+nFYcAhEc5pwYKI13bUvz4voiVufQiy3V8rzQKu21Sgl+dS2qcJavy7w==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
+      "integrity": "sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==",
       "dependencies": {
         "@rdfjs/types": "*",
         "rdf-data-factory": "^1.1.0",
         "rdf-string": "^1.6.0"
       }
     },
+    "node_modules/rdf-validate-datatype": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/rdf-validate-datatype/-/rdf-validate-datatype-0.1.5.tgz",
+      "integrity": "sha512-gU+cD+AT1LpFwbemuEmTDjwLyFwJDiw21XHyIofKhFnEpXODjShBuxhgDGnZqW3qIEwu/vECjOecuD60e5ngiQ==",
+      "dependencies": {
+        "@rdfjs/namespace": "^1.1.0",
+        "@rdfjs/to-ntriples": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.4"
+      }
+    },
+    "node_modules/rdf-validate-datatype/node_modules/@rdfjs/to-ntriples": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
+      "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q=="
+    },
+    "node_modules/rdf-validate-shacl": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/rdf-validate-shacl/-/rdf-validate-shacl-0.4.5.tgz",
+      "integrity": "sha512-tGYnssuPzmsPua1dju4hEtGkT1zouvwzVTNrFhNiqj2aZFO5pQ7lvLd9Cv9H9vKAlpIdC/x0zL6btxG3PCss0w==",
+      "dependencies": {
+        "@rdfjs/dataset": "^1.1.1",
+        "@rdfjs/namespace": "^1.0.0",
+        "@rdfjs/term-set": "^1.1.0",
+        "clownface": "^1.4.0",
+        "debug": "^4.3.2",
+        "rdf-literal": "^1.3.0",
+        "rdf-validate-datatype": "^0.1.5"
+      }
+    },
     "node_modules/rdfa-streaming-parser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-1.5.0.tgz",
-      "integrity": "sha512-A+Kl0vbRQKK3SqgWdCiR48Hi75LK6z6glPdGcbLXMw6qMRcLeIKe4p6yFkPXpbwtegmOa94uaxeLs5HMdo66AQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-2.0.1.tgz",
+      "integrity": "sha512-7Yyaj030LO7iQ38Wh/RNLVeYrVFJeyx3dpCK7C1nvX55eIN/gE4HWfbg4BYI9X7Bd+eUIUMVeiKYLmYjV6apow==",
       "dependencies": {
         "@rdfjs/types": "*",
-        "htmlparser2": "^6.0.0",
+        "htmlparser2": "^8.0.0",
         "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0",
         "relative-to-absolute-iri": "^1.0.2"
       }
     },
-    "node_modules/rdfa-streaming-parser/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/rdfa-streaming-parser/node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -10693,34 +9714,40 @@
         }
       ],
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/rdfxml-streaming-parser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.5.0.tgz",
-      "integrity": "sha512-pnt+7NgeqCMd2/rub+dqxzYJhZwJjBNU2BRwyYdCTmRZu2fr795jCPJB6Io5pjPzAt29ASqy+ODBSRMDKoKGbQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.2.3.tgz",
+      "integrity": "sha512-HoH8urnga+YQ5sDY9ufRb0wg6FvwR284sSXpZ+fJE5X5Oej6dfzkFer81uBNZzyNmzJR1TpMYMznyXEjPMLhCA==",
       "dependencies": {
         "@rdfjs/types": "*",
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
         "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0",
         "relative-to-absolute-iri": "^1.0.0",
-        "sax": "^1.2.4"
+        "validate-iri": "^1.0.0"
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/readable-stream-node-to-web": {
@@ -10734,6 +9761,19 @@
       "integrity": "sha512-G+0kz01xJM/uTuItKcqC73cifW8S6CZ7tp77NLN87lE5mrSU+GC8geoSAlfmp0NocmXckQ7W8s8ns73HYsIA3w==",
       "dependencies": {
         "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/readable-to-readable/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readable-web-to-node-stream": {
@@ -10751,6 +9791,38 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -10764,13 +9836,13 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10868,6 +9940,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -10900,6 +9977,14 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -10995,9 +10080,9 @@
       }
     },
     "node_modules/safe-stable-stringify": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
-      "integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
       "engines": {
         "node": ">=10"
       }
@@ -11007,48 +10092,10 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "node_modules/sax-stream": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax-stream/-/sax-stream-1.3.0.tgz",
-      "integrity": "sha512-tcfsAAICAkyNNe4uiKtKmLKxx3C7qPAej13UUoN+7OLYq/P5kHGahZtJhhMVM3fIMndA6TlYHWFlFEzFkv1VGg==",
-      "dependencies": {
-        "debug": "~2",
-        "sax": "~1"
-      }
-    },
-    "node_modules/sax-stream/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/sax-stream/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/saxes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dependencies": {
-        "xmlchars": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=v12.22.7"
-      }
-    },
     "node_modules/schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
@@ -11183,6 +10230,25 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/shaclc-parse": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/shaclc-parse/-/shaclc-parse-1.4.0.tgz",
+      "integrity": "sha512-zyxjIYQH2ghg/wtMvOp+4Nr6aK8j9bqFiVT3w47K8WHPYN+S3Zgnh2ybT+dGgMwo9KjiOoywxhjC7d8Z6GCmfA==",
+      "dependencies": {
+        "@rdfjs/types": "^1.1.0",
+        "n3": "^1.16.3"
+      }
+    },
+    "node_modules/shaclc-write": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/shaclc-write/-/shaclc-write-1.4.2.tgz",
+      "integrity": "sha512-aejD8fNgTfTINInjlwW7oz4GbmIJmDFJu4Tc3WVhmMH2QV24F+Ey/I/obMP/cQu/LwcfX7O2eu7bI9RUFeDMWw==",
+      "dependencies": {
+        "@jeswr/prefixcc": "^1.2.1",
+        "n3": "^1.16.3",
+        "rdf-string-ttl": "^1.3.2"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -11216,6 +10282,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -11494,60 +10565,52 @@
       "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
     },
     "node_modules/sparqlalgebrajs": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
-      "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.2.0.tgz",
+      "integrity": "sha512-tdlJdrvgQqgx9zubcl9iiyCxMOp4qRT2fs1Sne8X35QTm1Pj2ulB+gGEHunJJnw5FW7Uhtmw7J3px0sCmgJSbw==",
       "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/sparqljs": "^3.1.3",
         "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.0.4",
-        "rdf-isomorphic": "^1.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqljs": "^3.3.0"
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-isomorphic": "^1.3.0",
+        "rdf-string": "^1.6.0",
+        "rdf-terms": "^1.10.0",
+        "sparqljs": "^3.7.1"
       },
       "bin": {
         "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/sparqlee": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-1.10.0.tgz",
-      "integrity": "sha512-rKuyXIIyEsRsACZC86yrN0m/rUhKZQl6HfqeIqAC+5WXE08PB/tGQ9RPxiwo+P6u6QEk2Sd/h6Yq1pnT0607JA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-3.0.0.tgz",
+      "integrity": "sha512-/SCQekZMJaTVANUelbXFfZGrmzFViLO4DieTtAI0J32kE6CobxtwQf4prfFSjRrT43vitaUuLgcuCSlpQWNycQ==",
       "dependencies": {
+        "@comunica/bindings-factory": "^2.0.1",
         "@rdfjs/types": "*",
+        "@types/lru-cache": "^5.1.1",
         "@types/spark-md5": "^3.0.2",
         "@types/uuid": "^8.0.0",
-        "decimal.js": "^10.2.0",
+        "bignumber.js": "^9.0.1",
         "hash.js": "^1.1.7",
-        "immutable": "^3.8.2",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0",
+        "lru-cache": "^6.0.0",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-string": "^1.6.3",
         "relative-to-absolute-iri": "^1.0.6",
         "spark-md5": "^3.0.1",
-        "sparqlalgebrajs": "^3.0.2",
+        "sparqlalgebrajs": "^4.2.0",
         "uuid": "^8.0.0"
       },
       "bin": {
-        "sparqlee": "dist/bin/Sparqlee.js"
+        "sparqlee": "dist/bin/sparqlee.js"
       }
     },
-    "node_modules/sparqlee/node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
+    "node_modules/sparqlee/node_modules/@types/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
     },
     "node_modules/sparqlee/node_modules/uuid": {
       "version": "8.3.2",
@@ -11558,11 +10621,11 @@
       }
     },
     "node_modules/sparqljs": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.6.2.tgz",
-      "integrity": "sha512-KQEJPaOMeeDpdYYuiFb3JEErRLL8XqX4G7sdhZyHC6Qn4+PEMUff/EjUGkwcJ6aCC0JCTIgxDpRdE3+GFXpdxw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.1.tgz",
+      "integrity": "sha512-I1jYMtcwDkgCEqQ4eQuQIhB8hFAlRAJ6YDXDcV54XztaJaYRFqJlidHt77S3j8Mfh6kY6GK04dXPEIopxbEeuQ==",
       "dependencies": {
-        "rdf-data-factory": "^1.1.1"
+        "rdf-data-factory": "^1.1.2"
       },
       "bin": {
         "sparqljs": "bin/sparql-to-json"
@@ -11572,45 +10635,38 @@
       }
     },
     "node_modules/sparqljson-parse": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-1.7.0.tgz",
-      "integrity": "sha512-/88g7aK1QZ42YvMx+nStNeZsiVJhmg/OC4RNnQk+ybItvEkQiTOpnYDmST5FnzOIsSmp5RxAZDCIDdMK1h7Ynw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-2.2.0.tgz",
+      "integrity": "sha512-2TfvNvUsaJyWfCrq3ExdDdbF9LBLzIUCricg+D1YCYbbmyTzscgCtRk4KcIyJF178DtfCt4BkKzbKl8IXMHp8w==",
       "dependencies": {
+        "@bergos/jsonparse": "^1.4.1",
         "@rdfjs/types": "*",
-        "@types/node": "^13.1.0",
-        "JSONStream": "^1.3.3",
-        "rdf-data-factory": "^1.1.0"
+        "@types/readable-stream": "^2.3.13",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
       }
     },
-    "node_modules/sparqljson-parse/node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
-    },
     "node_modules/sparqljson-to-tree": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-2.1.0.tgz",
-      "integrity": "sha512-LwEMlrvjzEigatJ8iw1RKGWL9dKmATQNbTEXyadzsOQxbBhJNaGk8G9/WPCcVj2zlCPKGMysfNGb4UfvwHKeSw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-3.0.1.tgz",
+      "integrity": "sha512-WKDWCP6CM0Oa/OmzJJDpFudfa0yCcYnQoSPVb4RBp8XOYDOPn75fzrZURYQBSng/BUieT/zxaw68tstI6G3pSw==",
       "dependencies": {
         "rdf-literal": "^1.2.0",
-        "sparqljson-parse": "^1.6.0"
+        "sparqljson-parse": "^2.0.0"
       }
     },
     "node_modules/sparqlxml-parse": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-1.5.0.tgz",
-      "integrity": "sha512-+0DCekgO3G6ugeVntrZS6+Fj60MsHR0q51WoRAdVzARb5V3jhX3dZJbwSaeydsOsXrtts4XSMc/z+kbqy5/VUQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-2.1.1.tgz",
+      "integrity": "sha512-71sltShF6gDAzuKWEHNeij7r0Mv5VqRrvJing6W4WHJ12GRe6+t1IRTv6MeqxYN3XJmKevs7B3HCBUo7wceeJQ==",
       "dependencies": {
         "@rdfjs/types": "*",
-        "@types/node": "^13.1.0",
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
         "rdf-data-factory": "^1.1.0",
-        "sax-stream": "^1.2.3"
+        "readable-stream": "^4.0.0"
       }
-    },
-    "node_modules/sparqlxml-parse/node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
     },
     "node_modules/split-string": {
       "version": "3.1.0",
@@ -11654,6 +10710,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
@@ -11752,9 +10813,9 @@
       }
     },
     "node_modules/stream-to-string": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.0.tgz",
-      "integrity": "sha512-8drZlFIKBHSMdX9GCWv8V9AAWnQcTqw0iAI6/GC7UJ0H0SwKeFKjOoZfGY1tOU00GGU7FYZQoJ/ZCUEoXhD7yQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.1.tgz",
+      "integrity": "sha512-WsvTDNF8UYs369Yko3pcdTducQtYpzEZeOV7cTuReyFvOoA9S/DLJ6sYK+xPafSPHhUMpaxiljKYnT6JSFztIA==",
       "dependencies": {
         "promise-polyfill": "^1.1.6"
       }
@@ -11785,6 +10846,19 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/string-to-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -11796,6 +10870,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimend": {
@@ -11867,13 +10957,13 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.2.tgz",
+      "integrity": "sha512-Ah19JS86ypbJzTzvUCX7KOsEIhDaRONungA4aYBjEP3JZRf4ocuDzTg4QWZnPn9DEMiMYGJPiSOy7aykoCc70w==",
       "peer": true,
       "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -11885,16 +10975,16 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
-      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
+      "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
       "peer": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.14",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.0",
-        "terser": "^5.14.1"
+        "serialize-javascript": "^6.0.1",
+        "terser": "^5.16.8"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -11918,29 +11008,19 @@
         }
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
-      }
-    },
     "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
       "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
     },
     "node_modules/terser/node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "peer": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -11966,10 +11046,10 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    "node_modules/tinyduration": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.3.0.tgz",
+      "integrity": "sha512-sLR0iVUnnnyGEX/a3jhTA0QMK7UvakBqQJFLiibiuEYL6U1L85W+qApTZj6DcL1uoWQntYuL0gExoe9NU5B3PA=="
     },
     "node_modules/to-object-path": {
       "version": "0.3.0",
@@ -12049,14 +11129,19 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "node_modules/ts-guards": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/ts-guards/-/ts-guards-0.5.1.tgz",
+      "integrity": "sha512-Y6P/VJnwARiPMfxO7rvaYaz5tGQ5TQ0Wnb2cWIxMpFOioYkhsT8XaCrJX6wYPNFACa4UOrN5SPqhwpM8NolAhQ=="
+    },
     "node_modules/ts-morph": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-17.0.1.tgz",
-      "integrity": "sha512-10PkHyXmrtsTvZSL+cqtJLTgFXkU43Gd0JCc0Rw6GchWbqKe0Rwgt1v3ouobTZwQzF1mGhDeAlWYBMGRV7y+3g==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-19.0.0.tgz",
+      "integrity": "sha512-D6qcpiJdn46tUqV45vr5UGM2dnIEuTGNxVhg0sk5NX11orcouwj6i1bMqZIz2mZTZB1Hcgy7C3oEVhAT+f6mbQ==",
       "peer": true,
       "dependencies": {
-        "@ts-morph/common": "~0.18.0",
-        "code-block-writer": "^11.0.3"
+        "@ts-morph/common": "~0.20.0",
+        "code-block-writer": "^12.0.0"
       }
     },
     "node_modules/ts-node": {
@@ -12103,9 +11188,9 @@
       }
     },
     "node_modules/ts-node/node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "peer": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -12118,6 +11203,14 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -12190,6 +11283,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
@@ -12200,6 +11306,18 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -12299,9 +11417,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
       "funding": [
         {
           "type": "opencollective",
@@ -12310,6 +11428,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "peer": true,
@@ -12318,7 +11440,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -12342,6 +11464,11 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
       "deprecated": "Please see https://github.com/lydell/urix#deprecated"
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -12404,6 +11531,14 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/wac-allow": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wac-allow/-/wac-allow-1.0.0.tgz",
+      "integrity": "sha512-wKIb7+5HN3rsvXHq1D5BYaoYR0v+d6kkG/WZayCcpEP/+OpEx+zAYwRUABOjbELboirDRo9d6TOwNJ7AJLlSaQ==",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -12446,22 +11581,22 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.88.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
+      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
       "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^0.0.51",
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/wasm-edit": "1.11.1",
-        "@webassemblyjs/wasm-parser": "1.11.1",
+        "@types/estree": "^1.0.0",
+        "@webassemblyjs/ast": "^1.11.5",
+        "@webassemblyjs/wasm-edit": "^1.11.5",
+        "@webassemblyjs/wasm-parser": "^1.11.5",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.7.6",
+        "acorn-import-assertions": "^1.9.0",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.10.0",
-        "es-module-lexer": "^0.9.0",
+        "enhanced-resolve": "^5.15.0",
+        "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
@@ -12470,9 +11605,9 @@
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.1.0",
+        "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.1.3",
+        "terser-webpack-plugin": "^5.3.7",
         "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },
@@ -12525,9 +11660,9 @@
       }
     },
     "node_modules/webpack/node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "peer": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -12537,18 +11672,18 @@
       }
     },
     "node_modules/webpack/node_modules/acorn-import-assertions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
       "peer": true,
       "peerDependencies": {
         "acorn": "^8"
       }
     },
     "node_modules/webpack/node_modules/enhanced-resolve": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
-      "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -12606,10 +11741,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/winston": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
-      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.9.0.tgz",
+      "integrity": "sha512-jW51iW/X95BCW6MMtZWr2jKQBP4hV5bIDq9QrIjfDk6Q9QuxvTKEAlpUNAzP+HYHFFCeENhph16s0zEunu4uuQ==",
       "dependencies": {
         "@colors/colors": "1.5.0",
         "@dabh/diagnostics": "^2.0.2",
@@ -12640,6 +11794,32 @@
         "node": ">= 6.4.0"
       }
     },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -12648,6 +11828,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -12700,10 +11885,25 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "node_modules/xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
@@ -12732,9 +11932,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -12754,6 +11954,14 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ylru": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.3.2.tgz",
+      "integrity": "sha512-RXRJzMiK6U2ye0BlGGZnmpwJDPgakn6aNQ0A7gHRbD4I0uvK4TW6UqkK1V0pp9jskjJBAXd3dRrbzWkqJ+6cxA==",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/yn": {
@@ -12778,2892 +11986,2212 @@
     }
   },
   "dependencies": {
+    "@bergos/jsonparse": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.1.tgz",
+      "integrity": "sha512-vXIT0nzZGX/+yMD5bx2VhTzc92H55tPoehh1BW/FZHOndWGFddrH3MAfdx39FRc7irABirW6EQaGxIJYV6CGuA==",
+      "requires": {
+        "buffer": "^6.0.3"
+      }
+    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
-    "@comunica/actor-abstract-bindings-hash": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.22.0.tgz",
-      "integrity": "sha512-3Yrupl0AUFcPtxjImzvPSx6ygCgiJ4Ss0rFIhTuNRvTJohhYc/VpmPjqdprhghtHnhfmIEcqgb7TqdwqlntR2Q==",
+    "@comunica/actor-abstract-mediatyped": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.8.0.tgz",
+      "integrity": "sha512-UuqvlLmbGZKUnEfb9li7bzzLrL6fo/xSEIH0ZsLUj18ezcPMbEouRitK0rX+vgkRIQ+lrSP+bZ0vV7OWjizj8g==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "canonicalize": "^1.0.1",
-        "hash.js": "^1.1.7",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
       }
     },
-    "@comunica/actor-abstract-mediatyped": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.22.0.tgz",
-      "integrity": "sha512-+KQLPpx8GFqrhWFfuvrsA4Rjlfbo/QOIo2IvzSgmDwy6YVQZXaSQiNQv/BnrnedaFCf2ONV+w+PMLqXgzn8N9A==",
-      "requires": {}
-    },
     "@comunica/actor-abstract-parse": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.5.1.tgz",
-      "integrity": "sha512-KbkdI2QRH6gfVsDwufpj02jBSBMSG19xC1d52M1GG6MfdMoDNj2MLlcf0rXgYe1IePdCWf0qZzxqdu4fYQpYFw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.8.0.tgz",
+      "integrity": "sha512-zWxS4/dJSRU4ZvAYQeNmOVlCwVAqYs4+8ODGp1WZz04BwQvJ+dYld4m8mWei9roT486YRoZDTfWayEKTwmk9tw==",
       "requires": {
-        "@comunica/core": "^2.5.1",
+        "@comunica/core": "^2.8.0",
         "readable-stream": "^4.2.0"
-      },
-      "dependencies": {
-        "@comunica/core": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-          "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-          "requires": {
-            "@comunica/types": "^2.5.1",
-            "immutable": "^4.1.0"
-          }
-        },
-        "@comunica/types": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-          "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/yargs": "^17.0.13",
-            "asynciterator": "^3.8.0",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "immutable": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-        },
-        "readable-stream": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10"
-          }
-        },
-        "sparqlalgebrajs": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-          "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.3",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.6",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.6.1"
-          }
-        }
       }
     },
     "@comunica/actor-abstract-path": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.22.0.tgz",
-      "integrity": "sha512-S7IfWTKWvTTyRDiNb0NApLG1lwh3WKHmmBx6WqI3GicJfS+6kjZqrM2ke5OyVr2R6dpVfu6OnF0TiRYdPVgjEQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-2.8.0.tgz",
+      "integrity": "sha512-JFhAf72zeoWqPUyVFmSha1GpDPawxHu40kLKzsQ1OycNhmtaAh9jylFz0gOF6RMLCZlh8Yr4hptAVecdZRdJ0A==",
       "requires": {
-        "@comunica/types": "^1.22.0",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-context-preprocess-source-to-destination": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-1.22.0.tgz",
-      "integrity": "sha512-37aC7WacPIn7yObMubD3QvN0fze9kwBrHDf2M6cwe+54l3uCKYd8jeMH7pJTAT3eSLb32PYU1cxRiwRkQ8gVwQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-2.8.0.tgz",
+      "integrity": "sha512-W4puP9aN27utJeo7a73/uBGJfHtBzXMHIq9Fd3ip1zGODWNCMlz0ab/tci5kDN8wDhZxo920+CqVcVltqztRuQ==",
       "requires": {
-        "@comunica/context-entries": "^1.22.0"
+        "@comunica/bus-context-preprocess": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
       }
     },
     "@comunica/actor-dereference-fallback": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.5.1.tgz",
-      "integrity": "sha512-Yn3NFS73LV62QLYYzdGxTAROHr319D2RmNwXxkkz98oVFVkoWsWU+ojIA4n8yjceuHu0jXP5C0NNJIou+dR2lw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.8.0.tgz",
+      "integrity": "sha512-YL31QpzTK9rdJLeARCXqp/EGCHuigqUk+LqeEG3TXHs2ZFK9RYRzqKQe3B43Ak+9KJjoi/i0H11i7UEu8Qdrdg==",
       "requires": {
-        "@comunica/bus-dereference": "^2.5.1",
-        "@comunica/core": "^2.5.1"
-      },
-      "dependencies": {
-        "@comunica/core": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-          "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-          "requires": {
-            "@comunica/types": "^2.5.1",
-            "immutable": "^4.1.0"
-          }
-        },
-        "@comunica/types": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-          "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/yargs": "^17.0.13",
-            "asynciterator": "^3.8.0",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "immutable": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-        },
-        "sparqlalgebrajs": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-          "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.3",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.6",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.6.1"
-          }
-        }
+        "@comunica/bus-dereference": "^2.8.0",
+        "@comunica/core": "^2.8.0"
       }
     },
     "@comunica/actor-dereference-file": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-file/-/actor-dereference-file-2.5.1.tgz",
-      "integrity": "sha512-0+vnQ1KsTuRQRDz3vNSg23ohDS8oyY4zlsSIwyJAj1Ao4I5xhYtrt7h0up4o4hV2Qcy4ILoUGnVJzLaf0zCojQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-file/-/actor-dereference-file-2.8.0.tgz",
+      "integrity": "sha512-HhX+7DVvxc55LnWNFCGBgmObOBXayz8h2ho40LWASnP/IGAeGBxSST01T5ejcOLotBbirlOE1gp9QCZ+DygzQQ==",
       "requires": {
-        "@comunica/bus-dereference": "^2.5.1",
-        "@comunica/core": "^2.5.1"
-      },
-      "dependencies": {
-        "@comunica/core": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-          "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-          "requires": {
-            "@comunica/types": "^2.5.1",
-            "immutable": "^4.1.0"
-          }
-        },
-        "@comunica/types": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-          "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/yargs": "^17.0.13",
-            "asynciterator": "^3.8.0",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "immutable": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-        },
-        "sparqlalgebrajs": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-          "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.3",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.6",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.6.1"
-          }
-        }
+        "@comunica/bus-dereference": "^2.8.0",
+        "@comunica/core": "^2.8.0"
       }
     },
     "@comunica/actor-dereference-http": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-2.5.1.tgz",
-      "integrity": "sha512-Vy9IyaNgygp5qFB14/FV6bt77JQJgOfEfMopyC2f8KcMWmFHdbuRPVCv83kme4wouB6d6L0mCvQ2yT6uWQf8qQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-2.8.0.tgz",
+      "integrity": "sha512-iVvkCl3i3JCDQEOVFYUO3TMKuIbvn5ByeukZ0kHagYFNd8Buq9iIkxYKJHw7rMeGCmjpF+RekdGl/y7sGTHhDQ==",
       "requires": {
-        "@comunica/bus-dereference": "^2.5.1",
-        "@comunica/bus-http": "^2.5.1",
-        "@comunica/core": "^2.5.1",
+        "@comunica/bus-dereference": "^2.8.0",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/core": "^2.8.0",
         "cross-fetch": "^3.1.5",
         "relative-to-absolute-iri": "^1.0.7",
         "stream-to-string": "^1.2.0"
-      },
-      "dependencies": {
-        "@comunica/bus-http": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.5.1.tgz",
-          "integrity": "sha512-kouDqVoP6qAVQ4pflMmedBHfMtuLoBgqwX3mHdlUtrE0h1I+/EX6M5eUe5pXI6PfJrn3cInHyu+UZkbZYrykAw==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "is-stream": "^2.0.1",
-            "readable-stream-node-to-web": "^1.0.1",
-            "readable-web-to-node-stream": "^3.0.2",
-            "web-streams-ponyfill": "^1.4.2"
-          }
-        },
-        "@comunica/core": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-          "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-          "requires": {
-            "@comunica/types": "^2.5.1",
-            "immutable": "^4.1.0"
-          }
-        },
-        "@comunica/types": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-          "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/yargs": "^17.0.13",
-            "asynciterator": "^3.8.0",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "immutable": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-        },
-        "sparqlalgebrajs": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-          "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.3",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.6",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.6.1"
-          }
-        }
       }
     },
     "@comunica/actor-dereference-rdf-parse": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-2.5.1.tgz",
-      "integrity": "sha512-24u/lt1yJcwAijwJSfOI19L6ZAMmctgyJFrZRjvwPG+g3kl9Eyqw0WdWhKijOj+/bS3nSaQGKL7MlUkYM6VZfQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-2.8.0.tgz",
+      "integrity": "sha512-bMVzK4RBnvmH8lh7jRXar7EXZoTvdYBl8lX+4U9t3djKByv7JUNNx0jRMDfFF6L+uNYy5i4JNlPJt6W0E49Wfg==",
       "requires": {
-        "@comunica/bus-dereference": "^2.5.1",
-        "@comunica/bus-dereference-rdf": "^2.5.1",
-        "@comunica/bus-rdf-parse": "^2.5.1"
+        "@comunica/bus-dereference": "^2.8.0",
+        "@comunica/bus-dereference-rdf": "^2.8.0",
+        "@comunica/bus-rdf-parse": "^2.8.0"
+      }
+    },
+    "@comunica/actor-hash-bindings-sha1": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-sha1/-/actor-hash-bindings-sha1-2.8.0.tgz",
+      "integrity": "sha512-izgsb2WFQSmcbgzjphoFySzfUS3win/FfNPXzf1v9LCx05Yu4tqz9M1ZDu3C1nR1iNrIFFZ7On7Dg2RU0UfuXg==",
+      "requires": {
+        "@comunica/bus-hash-bindings": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "canonicalize": "^2.0.0",
+        "hash.js": "^1.1.7",
+        "rdf-string": "^1.6.1"
       },
       "dependencies": {
-        "@comunica/actor-abstract-mediatyped": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.5.1.tgz",
-          "integrity": "sha512-Iz8j1XqXp/A7HJVDTtEtp7hV6nuNoIjjEUgiJUiBTM5OIx7sFbGfUd10VtHPSXB/3lHHcIo34BKNZkeurNo6BA==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1"
-          }
-        },
-        "@comunica/bus-rdf-parse": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.5.1.tgz",
-          "integrity": "sha512-BzfvedLkh1bOSa/WeUzLc/bQlcXWKhIkG/GwIOrCFtoWJOdOlapWdPvPS5U6sEW/UW454ClRWaqIA+GM0qeyzA==",
-          "requires": {
-            "@comunica/actor-abstract-mediatyped": "^2.5.1",
-            "@comunica/actor-abstract-parse": "^2.5.1",
-            "@comunica/core": "^2.5.1",
-            "@rdfjs/types": "*"
-          }
-        },
-        "@comunica/core": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-          "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-          "requires": {
-            "@comunica/types": "^2.5.1",
-            "immutable": "^4.1.0"
-          }
-        },
-        "@comunica/types": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-          "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/yargs": "^17.0.13",
-            "asynciterator": "^3.8.0",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "immutable": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-        },
-        "sparqlalgebrajs": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-          "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.3",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.6",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.6.1"
-          }
+        "canonicalize": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.0.0.tgz",
+          "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w=="
         }
       }
     },
     "@comunica/actor-http-fetch": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-2.5.1.tgz",
-      "integrity": "sha512-2E25qKw2+16iWOHfaaGkbzv14owMwN3UGWURPaLyFIOa8S6xkjU/8CMWRjaGibee2KOC8TKUioeQ+YJCweIC/w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-2.8.0.tgz",
+      "integrity": "sha512-Eqdkx2SZHdJ4GJeO87jslUCVMUEhi+hvUbh9Hstvksf0aShN/SNBzjfbEITBUkbo15WR5ZdFd4EZDLKBs9yTvQ==",
       "requires": {
-        "@comunica/bus-http": "^2.5.1",
-        "@comunica/context-entries": "^2.5.1",
-        "@comunica/mediatortype-time": "^2.5.1",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/mediatortype-time": "^2.8.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.5"
-      },
-      "dependencies": {
-        "@comunica/bus-http": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.5.1.tgz",
-          "integrity": "sha512-kouDqVoP6qAVQ4pflMmedBHfMtuLoBgqwX3mHdlUtrE0h1I+/EX6M5eUe5pXI6PfJrn3cInHyu+UZkbZYrykAw==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "is-stream": "^2.0.1",
-            "readable-stream-node-to-web": "^1.0.1",
-            "readable-web-to-node-stream": "^3.0.2",
-            "web-streams-ponyfill": "^1.4.2"
-          }
-        },
-        "@comunica/context-entries": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.5.1.tgz",
-          "integrity": "sha512-TnF476Nv9+DfZ+JLTQU7OSqmFREScVkpBtU71seT6He+vkJBHDm6Nq4tnKwDmAI3v9dCc5dgCRU4F2uPDjBKZA==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1",
-            "@rdfjs/types": "*",
-            "jsonld-context-parser": "^2.2.2",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "@comunica/core": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-          "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-          "requires": {
-            "@comunica/types": "^2.5.1",
-            "immutable": "^4.1.0"
-          }
-        },
-        "@comunica/types": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-          "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/yargs": "^17.0.13",
-            "asynciterator": "^3.8.0",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "immutable": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-        },
-        "sparqlalgebrajs": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-          "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.3",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.6",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.6.1"
-          }
-        }
-      }
-    },
-    "@comunica/actor-http-memento": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.22.1.tgz",
-      "integrity": "sha512-H10dWC+RA/xkhORKBMUIw133PxKXmo8ByEeYgbV3QplyeZ5+Wv+0hh+Icil4rC5rsqcpW+iU2TZGK6vfsTQpMQ==",
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/parse-link-header": "^1.0.0",
-        "cross-fetch": "^3.0.5",
-        "parse-link-header": "^1.0.1"
-      }
-    },
-    "@comunica/actor-http-native": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.22.1.tgz",
-      "integrity": "sha512-BdB+hvQ9CJF9tI42hNhcvTMagOty+jw21LIQDJWI628xMcXZ88BJaUX0Ulc7g2nrWH97ZRm5+KjLC4Zf+OGwZg==",
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/parse-link-header": "^1.0.0",
-        "cross-fetch": "^3.0.5",
-        "follow-redirects": "^1.5.1",
-        "parse-link-header": "^1.0.1"
-      }
-    },
-    "@comunica/actor-http-node-fetch": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-node-fetch/-/actor-http-node-fetch-1.21.2.tgz",
-      "integrity": "sha512-6TIL5WhHd8CZasgU4EgXn9GovZ51xexshxolo4rN7xI5uzfGXemHWHVQwiPJNdBbud/Hi7nCJJNrBRtdI/b2pw==",
-      "requires": {
-        "@comunica/context-entries": "^1.21.1",
-        "cross-fetch": "^3.0.5"
       }
     },
     "@comunica/actor-http-proxy": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.21.1.tgz",
-      "integrity": "sha512-Z3NvOzZeffZ+aRBZVg3apbVSNjYvAUE49oOL+BrBtT5CuEf+RUOCcSOV/UhpITIFg21/uuyaxvJaT5RmfH+xzw==",
-      "requires": {}
-    },
-    "@comunica/actor-init-sparql": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.21.3.tgz",
-      "integrity": "sha512-R7auYy7gppLt0nUAc+Y+3mjYmwaLzr02PTx9XGO/ojUi/LnCuU2lrS2Fik90b9N3kg5kDJYN/znT/XHpy5vdGg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.8.0.tgz",
+      "integrity": "sha512-03ltsJrhYnBEc7TwTEHe99KdsCnG8x/XkaA3jeiG99co+xxrbNgjgNJLOZl8aA08Ogaur1Sb+UuiCB9jrSLRxA==",
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.21.1",
-        "@comunica/actor-abstract-mediatyped": "^1.21.1",
-        "@comunica/actor-context-preprocess-source-to-destination": "^1.21.1",
-        "@comunica/actor-http-memento": "^1.21.1",
-        "@comunica/actor-http-native": "^1.21.3",
-        "@comunica/actor-http-proxy": "^1.21.1",
-        "@comunica/actor-optimize-query-operation-join-bgp": "^1.21.1",
-        "@comunica/actor-query-operation-ask": "^1.21.1",
-        "@comunica/actor-query-operation-bgp-empty": "^1.21.1",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.21.2",
-        "@comunica/actor-query-operation-bgp-single": "^1.21.1",
-        "@comunica/actor-query-operation-construct": "^1.21.1",
-        "@comunica/actor-query-operation-describe-subject": "^1.21.1",
-        "@comunica/actor-query-operation-distinct-hash": "^1.21.1",
-        "@comunica/actor-query-operation-extend": "^1.21.2",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.21.2",
-        "@comunica/actor-query-operation-from-quad": "^1.21.1",
-        "@comunica/actor-query-operation-group": "^1.21.1",
-        "@comunica/actor-query-operation-join": "^1.21.1",
-        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.21.1",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.21.2",
-        "@comunica/actor-query-operation-minus": "^1.21.1",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.21.2",
-        "@comunica/actor-query-operation-path-alt": "^1.21.1",
-        "@comunica/actor-query-operation-path-inv": "^1.21.1",
-        "@comunica/actor-query-operation-path-link": "^1.21.1",
-        "@comunica/actor-query-operation-path-nps": "^1.21.1",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.21.1",
-        "@comunica/actor-query-operation-path-seq": "^1.21.1",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.21.1",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.21.1",
-        "@comunica/actor-query-operation-project": "^1.21.1",
-        "@comunica/actor-query-operation-quadpattern": "^1.21.1",
-        "@comunica/actor-query-operation-reduced-hash": "^1.21.1",
-        "@comunica/actor-query-operation-service": "^1.21.1",
-        "@comunica/actor-query-operation-slice": "^1.21.1",
-        "@comunica/actor-query-operation-sparql-endpoint": "^1.21.2",
-        "@comunica/actor-query-operation-union": "^1.21.1",
-        "@comunica/actor-query-operation-update-add-rewrite": "^1.21.1",
-        "@comunica/actor-query-operation-update-clear": "^1.21.1",
-        "@comunica/actor-query-operation-update-compositeupdate": "^1.21.1",
-        "@comunica/actor-query-operation-update-copy-rewrite": "^1.21.1",
-        "@comunica/actor-query-operation-update-create": "^1.21.1",
-        "@comunica/actor-query-operation-update-deleteinsert": "^1.21.1",
-        "@comunica/actor-query-operation-update-drop": "^1.21.1",
-        "@comunica/actor-query-operation-update-load": "^1.21.1",
-        "@comunica/actor-query-operation-update-move-rewrite": "^1.21.1",
-        "@comunica/actor-query-operation-values": "^1.21.1",
-        "@comunica/actor-rdf-dereference-fallback": "^1.21.1",
-        "@comunica/actor-rdf-dereference-http-parse": "^1.21.2",
-        "@comunica/actor-rdf-join-multi-smallest": "^1.21.1",
-        "@comunica/actor-rdf-join-nestedloop": "^1.21.1",
-        "@comunica/actor-rdf-join-symmetrichash": "^1.21.1",
-        "@comunica/actor-rdf-metadata-all": "^1.21.1",
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.21.1",
-        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.21.1",
-        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^1.21.1",
-        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.21.2",
-        "@comunica/actor-rdf-metadata-primary-topic": "^1.21.1",
-        "@comunica/actor-rdf-parse-html": "^1.21.1",
-        "@comunica/actor-rdf-parse-html-microdata": "^1.21.1",
-        "@comunica/actor-rdf-parse-html-rdfa": "^1.21.1",
-        "@comunica/actor-rdf-parse-html-script": "^1.21.1",
-        "@comunica/actor-rdf-parse-jsonld": "^1.21.2",
-        "@comunica/actor-rdf-parse-n3": "^1.21.1",
-        "@comunica/actor-rdf-parse-rdfxml": "^1.21.1",
-        "@comunica/actor-rdf-parse-xml-rdfa": "^1.21.1",
-        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.21.1",
-        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.21.1",
-        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.21.1",
-        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.21.1",
-        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.21.2",
-        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.21.1",
-        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.21.1",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.21.1",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.21.1",
-        "@comunica/actor-rdf-serialize-n3": "^1.21.1",
-        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^1.21.1",
-        "@comunica/actor-rdf-update-quads-hypermedia": "^1.21.1",
-        "@comunica/actor-rdf-update-quads-rdfjs-store": "^1.21.1",
-        "@comunica/actor-sparql-parse-algebra": "^1.21.1",
-        "@comunica/actor-sparql-parse-graphql": "^1.21.1",
-        "@comunica/actor-sparql-serialize-json": "^1.21.1",
-        "@comunica/actor-sparql-serialize-rdf": "^1.21.1",
-        "@comunica/actor-sparql-serialize-simple": "^1.21.1",
-        "@comunica/actor-sparql-serialize-sparql-csv": "^1.21.1",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.21.1",
-        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.21.1",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.21.1",
-        "@comunica/actor-sparql-serialize-stats": "^1.21.1",
-        "@comunica/actor-sparql-serialize-table": "^1.21.1",
-        "@comunica/actor-sparql-serialize-tree": "^1.21.1",
-        "@comunica/bus-context-preprocess": "^1.21.1",
-        "@comunica/bus-http": "^1.21.1",
-        "@comunica/bus-http-invalidate": "^1.21.1",
-        "@comunica/bus-init": "^1.21.1",
-        "@comunica/bus-optimize-query-operation": "^1.21.1",
-        "@comunica/bus-query-operation": "^1.21.1",
-        "@comunica/bus-rdf-dereference": "^1.21.1",
-        "@comunica/bus-rdf-dereference-paged": "^1.21.1",
-        "@comunica/bus-rdf-join": "^1.21.1",
-        "@comunica/bus-rdf-metadata": "^1.21.1",
-        "@comunica/bus-rdf-metadata-extract": "^1.21.1",
-        "@comunica/bus-rdf-parse": "^1.21.1",
-        "@comunica/bus-rdf-parse-html": "^1.21.1",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.21.1",
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.21.1",
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.21.1",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
-        "@comunica/bus-rdf-serialize": "^1.21.1",
-        "@comunica/bus-rdf-update-hypermedia": "^1.21.1",
-        "@comunica/bus-rdf-update-quads": "^1.21.1",
-        "@comunica/bus-sparql-parse": "^1.21.1",
-        "@comunica/bus-sparql-serialize": "^1.21.1",
-        "@comunica/context-entries": "^1.21.1",
-        "@comunica/core": "^1.21.1",
-        "@comunica/logger-pretty": "^1.21.1",
-        "@comunica/logger-void": "^1.21.1",
-        "@comunica/mediator-all": "^1.21.1",
-        "@comunica/mediator-combine-pipeline": "^1.21.1",
-        "@comunica/mediator-combine-union": "^1.21.1",
-        "@comunica/mediator-number": "^1.21.1",
-        "@comunica/mediator-race": "^1.21.1",
-        "@comunica/runner": "^1.21.1",
-        "@comunica/runner-cli": "^1.21.1",
-        "@types/minimist": "^1.2.0",
-        "@types/rdf-js": "*",
-        "asynciterator": "^3.1.0",
-        "minimist": "^1.2.0",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/mediatortype-time": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "@comunica/actor-http-wayback": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-wayback/-/actor-http-wayback-2.8.0.tgz",
+      "integrity": "sha512-Iam675J8f08CJfIbXjJs2coZxhXan+K7q18+DMv1veuXXH3Wrh1x7g2EcH8vdDH/G52bG2oZ02KsodWGvLVz7g==",
+      "requires": {
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "cross-fetch": "^3.1.5",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "@comunica/actor-init-query": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-2.8.0.tgz",
+      "integrity": "sha512-Zd2SlaCiZZ3inEQHvXgX1MIjQDUWsqkMEo2MQOUYibHGDvjdGxUDJCmc3TYBv+I3wdjH+991GVSsSS+mFB+DAQ==",
+      "requires": {
+        "@comunica/actor-http-proxy": "^2.8.0",
+        "@comunica/bus-context-preprocess": "^2.8.0",
+        "@comunica/bus-http-invalidate": "^2.8.0",
+        "@comunica/bus-init": "^2.8.0",
+        "@comunica/bus-optimize-query-operation": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-query-parse": "^2.8.0",
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/logger-pretty": "^2.8.0",
+        "@comunica/runner": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.13",
+        "asynciterator": "^3.8.0",
         "negotiate": "^1.0.1",
-        "rdf-quad": "^1.4.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.5.5",
-        "streamify-string": "^1.0.1"
+        "process": "^0.11.10",
+        "rdf-quad": "^1.5.0",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^4.2.0",
+        "streamify-string": "^1.0.1",
+        "yargs": "^17.6.2"
+      }
+    },
+    "@comunica/actor-optimize-query-operation-bgp-to-join": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-2.8.0.tgz",
+      "integrity": "sha512-3ZIRLI0lFSLy4QDW/ml8I4je/d6zr+jnI1sMOfkVibpxAWfKXxfgB0IVCpTheiSYVie3SycBET77Q9fwQpidyQ==",
+      "requires": {
+        "@comunica/bus-optimize-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-optimize-query-operation-join-bgp": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.22.0.tgz",
-      "integrity": "sha512-G0JSVM0q2kJb4X6p/zTyuMi4E5vdQsrJjx6Zy9FIG2EySAP+Q/M8TNSteJbyan07xZwxane6bZcCckvNyDVqTg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-2.8.0.tgz",
+      "integrity": "sha512-pmH0WRPQOQyu2ilD01EZmJn2gSTCmDFjw/H6IBCTSLH4umvaka3i0Duu5vHhw/1FpHi8juY/z5MotraoIMObjw==",
       "requires": {
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-optimize-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "@comunica/actor-optimize-query-operation-join-connected": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-2.8.0.tgz",
+      "integrity": "sha512-mk7BE743NY6KcgPuP1jIj7n5/zR0KmUCtPh3/Odi0PH435PlbdQwjetoWpgeUMTrn40r4dsLzIfqPNBplAKIOA==",
+      "requires": {
+        "@comunica/bus-optimize-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-ask": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.22.0.tgz",
-      "integrity": "sha512-kdByALpa1SM0PFlHarDQc6KjGXZ1xaTwvmhdldov7XN6KmXZyozic0qx29d5kNgMUsDOfaTbxPZFNmBRr32K0w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-2.8.0.tgz",
+      "integrity": "sha512-OGYRBI3w/YX9PcII8M4HICERGtnRWBlbLcTZlA8YIF2qBtOPIKqMYqg/GRiCmrgaoNVut6xRDYtZ8TW1pVkjHg==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
-    "@comunica/actor-query-operation-bgp-empty": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.22.0.tgz",
-      "integrity": "sha512-qitWhNrmehzvnNHZ98QuClOATyNRYte98OtR/C3trljMWjOrnC8pnstUHS5BN3bOBftRCBjO6ukJcnfgZFeNTQ==",
+    "@comunica/actor-query-operation-bgp-join": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-2.8.0.tgz",
+      "integrity": "sha512-W0BUxlfO8HEnmBKB+8J1kPQy/j1OA1xn3NIXL0kyIorTv3g7bIXHRac1gr/gRzAkqvKCFYQ2KPwcu6wQvZnGUg==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
-      }
-    },
-    "@comunica/actor-query-operation-bgp-left-deep-smallest": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.22.0.tgz",
-      "integrity": "sha512-c6u9knbOLh7W4JNGZh0Vc2dMCsDzm5/tjhhKttbvLuN8bGqvdx2Pxuv0beTyWSXhLXxeo6DkhtWAh/b+gtNBRw==",
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
-      }
-    },
-    "@comunica/actor-query-operation-bgp-single": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.22.0.tgz",
-      "integrity": "sha512-wxOO1Df9oRiAHUgZWx+o7zP+PZF/7kkHCueBWnvFA9Qqlw3naJLoFuAnhxSh1Ej4p5XGldjd1Bt/7VUFgfKOvQ==",
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-construct": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.22.0.tgz",
-      "integrity": "sha512-URXw1bip+ZmBfcN6lksOMKfTOO7OuBZhJc09s6EiyBTfHbBxPmLEhkv/d/hzNiEf2D+LYHjmqRHq6gSh93g//g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-2.8.0.tgz",
+      "integrity": "sha512-I0pc1pxNau/MfdLcfo6Q3ihVDY9f6PMmEGseJtM9KMsMRyl8mPmfIkb7o9JHul5Uw+89lg1jmuEXBU/RGQx7ig==",
       "requires": {
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-describe-subject": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.22.0.tgz",
-      "integrity": "sha512-DrBhicGLF00VYv6+QJ04tmKAn6nGQ0Yyih01K++yNfXByBL++1iXFrYwoLwQAJQZJ6H5FRLhYGMaB12mLq/wvQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-2.8.0.tgz",
+      "integrity": "sha512-ZrvfwX3wtATZqGwy/oUXrwiKlc41+aWYmU/aD4O7mZ358PcVDu/4VND8cySModfYHM78tXgeU8dHOntheoQZlQ==",
       "requires": {
-        "@comunica/actor-query-operation-union": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/actor-query-operation-union": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-distinct-hash": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.22.0.tgz",
-      "integrity": "sha512-6anXCszrUDoBZdOhLBmsBFxQR/P5tPsuzGFuXP+pf7zI9zIU6nfaMeffOj+GDPClReyXf1UmyJXsIKo7r5WWUg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-2.8.0.tgz",
+      "integrity": "sha512-LFxDeDovi8lHnSCDwIzVZztqlK4Ph4PNSvNILhIOCc7RFr32ljxzvivw7s03ePVebxDhCI/Aqm9c7bm2ndM6Ug==",
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-hash-bindings": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-extend": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.22.0.tgz",
-      "integrity": "sha512-61AOM+62/Xtfd+5XtWiJUlcmK5oKQ2z77s5we2Z9AIrsxqKM90RdU9/t7U1g/3SrMiCMPNrN6mPfYiz7yG9pfA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-2.8.0.tgz",
+      "integrity": "sha512-4Dlut/Eg/N9+43fWWX0tQNNPvfq0oTx8YXp7pcZXNVhEKAVZ/kjZCQo6S3lu9TkItefyonLWgHg/leuSqu+GUg==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.2",
-        "sparqlee": "^1.10.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqlee": "^3.0.0"
       }
     },
     "@comunica/actor-query-operation-filter-sparqlee": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.22.0.tgz",
-      "integrity": "sha512-FceqE7qlPUADr3lbUbVKFL245IPNGS2OwFPIN6ksGPe1y/Cgd7f/lLpqmURxzpPELm76VgJQM5VzMOeDuwlt9Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-2.8.0.tgz",
+      "integrity": "sha512-gGjM9U090TUd0VIN0NIH9EcBupNh5TYq/EEXLxYWbwK+DjyBYk0zN2En/6HUCcM+tFYlPfj264m1g/9V2gzWwg==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqlee": "^3.0.0"
       }
     },
     "@comunica/actor-query-operation-from-quad": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.22.0.tgz",
-      "integrity": "sha512-rkVS/YMOb50F7vo45jgvyErbiG17DDj0pSaaMo1Dm1XWohXOvXOMoJtE+x0iTISEbw8F+g/oPjUhns3VOR38hw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-2.8.0.tgz",
+      "integrity": "sha512-7rpan2gvDmWGr57B7gIi2I1Vva0cXuYQG2ZLE9aEA6HGzqHtd37a9zhmURyUOSXm/VGWTVtBrQ/UqhSFFLLRkQ==",
       "requires": {
-        "@comunica/types": "^1.22.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-group": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.22.0.tgz",
-      "integrity": "sha512-EQCV/eFMTcplqwxcX0uR+cyaExrW0xIJPRJZkJpLX1mKYoeYh43FwYj6HQy00gwXImYYqFXw03lU0x+9P3dGLA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-2.8.0.tgz",
+      "integrity": "sha512-n34wfdnvJ8b3DspNt4OfY2jREtPoghSleALRdKww15pXY2zyGFSyigKL5lPI+KyM4i+c/htKQz+ZruAPG7/nFg==",
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-hash-bindings": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqlee": "^3.0.0"
       }
     },
     "@comunica/actor-query-operation-join": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.22.0.tgz",
-      "integrity": "sha512-QJBU4Vm438SGxqpV8g+vDg7IsETCfoHsl6GaZdFb8qT8EfSeIqd/oYAKJJMH/a6SzV5f8zRwDtXeWmDcA3fS1w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-2.8.0.tgz",
+      "integrity": "sha512-2pGRJqY3rDHkX9tbGlAQWHOnOlQcI23j1IwKQSJCgOfmoq2TG21fde4sL4ehpoaF78P0bwhQKiYIJai+PZE0ew==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
-    "@comunica/actor-query-operation-leftjoin-left-deep": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.22.0.tgz",
-      "integrity": "sha512-JetWHipImYLXffNVmSk0Q2f0CJYmO4UWjb1rixNtih2Plu10BWpwLICNhw6bnuco5LJb3/EdEmDBrWrkztXH6Q==",
+    "@comunica/actor-query-operation-leftjoin": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-2.8.0.tgz",
+      "integrity": "sha512-e6z/M3/HNUdJZ8ISvvynBaOib8aSEhwYTM7fj5ctCr38vP4pb4cDkxtsTpI3Di4jTgOGQ96Tl7SR3dEXzctqvA==",
       "requires": {
-        "@comunica/bus-rdf-join": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
-      }
-    },
-    "@comunica/actor-query-operation-leftjoin-nestedloop": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.22.0.tgz",
-      "integrity": "sha512-NttPFDGr9vWJh5iYNz/xhLPTo7TEFc45D2UqAVa0bF2XyHSM0T+oVXKEZre+FqSxTxSxHUQ22vUXY9vctnO4Xg==",
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqlee": "^3.0.0"
       }
     },
     "@comunica/actor-query-operation-minus": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.22.0.tgz",
-      "integrity": "sha512-53f6V6XdypGu0aaFMHr6TcE1hOqoDHphNfd1OE/CRDbNfbK+ELz2pWTnGoWf6zGRW4srnCGA3Q5vtZpSNpOMHQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-2.8.0.tgz",
+      "integrity": "sha512-OeVn6UvLd+NljSPsPjIDGSKjbe/nR4Aq4Ps2iudzAw4SNiw3x03o21DMIHxNSDvPVuAaYQJq/7LyeCBvUDrq3Q==",
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "@comunica/actor-query-operation-nop": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-2.8.0.tgz",
+      "integrity": "sha512-GqtoM1rXmplAaaBMtALbtYbIvGUlPipycYJxlzHTkXTlBJHkikBUJb8qL5W4LAWm6yZ60l1nFYmtwb6ueifXGg==",
+      "requires": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-orderby-sparqlee": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.22.0.tgz",
-      "integrity": "sha512-5R4li6DxPvSrsr5oGi8hACmSBtARD/W6EzUhEiN7IRF1UjBMGMttKo/BrlcBKsolirWrPmvNsz9Y9eLSgcxx9Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-2.8.0.tgz",
+      "integrity": "sha512-EgtEEic3vKT8EZw5NpqsV0NMzk4nwgng/gKwGQGezc2D3ZmCJv/Cho/f2E/PpuBO7s7/mJ9OmeyxNGTLY0SDJA==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqlee": "^3.0.0"
       }
     },
     "@comunica/actor-query-operation-path-alt": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.22.0.tgz",
-      "integrity": "sha512-mEDuira41HEcDdjCXcE9ofkDRD+mBOAKMKR6yl/C/xZdeC2ol/XltqbP7nZdxafgQ7rPCVAbsf0dyC2rU6uSNg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-2.8.0.tgz",
+      "integrity": "sha512-9qLMSax4hNKFUFJtmNE1/Gtu4Qc4Y3KVGqLj6q09mEODB+9IXMsBXtvXJlBLxfG9I0YwI/NC4fZudKMeAmw5zQ==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/actor-query-operation-union": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-path-inv": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.22.0.tgz",
-      "integrity": "sha512-ZJnURpQ5JaxRR6Neh/Uea+bEVaeKFZCvVjMFxcPPelP/Xj7Bu7qSklhwwUCjgwvJafDYpdgvPNll9qV8QiQ8QA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-2.8.0.tgz",
+      "integrity": "sha512-rbvkIoKgQHp4hff19Rrcf2LLvRMa3gibtDMk5G3bi+3GIPD8TOBI6e5ZBsOz3jQLyEAcRcHurzipeGWC/1gPFg==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0"
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-path-link": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.22.0.tgz",
-      "integrity": "sha512-xVqbgx8iF4YKgD4wf3CHBiTaOK+uj3IZsr/pB2xMUYL263tZCmRNF8xY9+pqnogb+7bOp2tvAn1lRXl7sydGrg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-2.8.0.tgz",
+      "integrity": "sha512-eCruNrzExWKb2SaAQBYIPfMjsq724JE9vwUm2FimJD+9UqNnMKkO9fkNdwcWzzPQuwG7XVJGIaOKE1kpO+zl6g==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-path-nps": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.22.0.tgz",
-      "integrity": "sha512-aBM44q3wjFz7J9nuPVEI0kpsFXcN14LK1bih8SwiUz8DMb+Ls4pODgWN00Y4PZgB6Aqf3NL9bRr/8UlheQZ56A==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-2.8.0.tgz",
+      "integrity": "sha512-VO0ThXhRviHvZ12D7rL4ooulwFp3fZxiTLblRqg9sE8pbpNzocOTfgIz0C06kXzEdQNl33ztHQ3DCvFCeyI9cw==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-path-one-or-more": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.22.0.tgz",
-      "integrity": "sha512-lc8Qp9HhMwmhLI+PFpchmExFtivbDDR8EhFUsFt0LZuSLvmz4nH1wxrOLnL99/054RIisNyz7pYa+CzAsE5KUg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-2.8.0.tgz",
+      "integrity": "sha512-vQ1UcY4EysELBVfXtHs8m6Macp6XHWsYVEkn3o/Dln9Rj7+gQy3rqHFmCWwcK0lUaldiugWqhK/wiMxpe7ZFZQ==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-path-seq": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.22.0.tgz",
-      "integrity": "sha512-9oLdRJr9kDab0wzg75Ki54CxLkeU2lYMNGpPCj5AAtFXlXwCL3qiVnkNBjGdgyLLwg8hd6cQeOG12SYEcSfFDQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-2.8.0.tgz",
+      "integrity": "sha512-uH/dUaEaM5qBb3T/UoAxuVuf1AI3R3NuDzWKPytsH3EgTPz6Sl4QfU8wFcofVI4NYn3bptnoOf19eInWmbnMIw==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.22.0.tgz",
-      "integrity": "sha512-u9+v07ZxadcYiKTkrXW1GMiBAuS0Bi7N5Z1iPQSgD0HHC8p2JsNySteY4U9eSO5Y4lht8koeSGanplmCZY/YhA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-2.8.0.tgz",
+      "integrity": "sha512-zbylKeSK3uEyFf6co40i8QmR9o+WHq+1+R0A8KczymI7snNkzGdz9tIY7NKAGpAtg9fajPg3cXzj5P7tJyMpIg==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.22.0.tgz",
-      "integrity": "sha512-RnjN9y6oat2kZtYvcxBdyY29oDrO2ZH6sTwEDX4qro10QkfHm5Pa4SPGSoIdj5x1g5meeOOXisqKoZHQZUTJfA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-2.8.0.tgz",
+      "integrity": "sha512-1pR+UqROcBwItctc4z/Vjxe2EUovU7RbYBkAi9mmtxt0Zn6v6xK54c7zPZy7VwmadZXuUsLgjb0AgS+2RZr34w==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/actor-abstract-path": "^2.8.0",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-project": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.22.0.tgz",
-      "integrity": "sha512-qjvpx4rto/CK/xefDn3232R0Ilc4DrhK5xl8RK7/l5Yn1/yFgWnqHK2sY+51O2/qeOkqYrb9ojoT9PwXHaLyXA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-2.8.0.tgz",
+      "integrity": "sha512-xVhoEPtxDP61Y0twg2uNj3jEotfjFASFwv6uHtXhpUTrWYKHBiYUsYIrA0FyQpFJ/QzuytY7Ci46RWWUSRqz6g==",
       "requires": {
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/data-factory": "^2.7.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-quadpattern": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.22.0.tgz",
-      "integrity": "sha512-kNNPhM28JCiJ/iYpobM+wv6Y71Q3adWTlt2GM1MF8ckU9Fa+IwdlFaZ9oYaLudLpPW48QtAXDLZgiNtZEhPNAg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-2.8.0.tgz",
+      "integrity": "sha512-jwxNcbf6+f1/Zrc8J9GY9VjsjU7h6f9+gX/O0xmGnU8XKFRWwtHjlRe5Bfw7o/r4PDWtpTQ62vfko9U+iJqe1g==",
       "requires": {
-        "@comunica/types": "^1.22.0",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.3",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-reduced-hash": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.22.0.tgz",
-      "integrity": "sha512-vymsRgS+c4J48uzyvSIb/Qj1sJ1DEqRZXuQuw8KhCCzWmCRA49DPpx2lg2sc6PJJTjyQAU3xbqHVaZUyX5e9jQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-2.8.0.tgz",
+      "integrity": "sha512-m0b6xRY+cKxajgqwX2Tvc3XCXlj7aEfHamolMRGK9sKN5nuj4GzU05CNRKo+2wXoHLLmMMF+B+dGk+kg5gc5hg==",
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@types/lru-cache": "^5.1.0",
-        "lru-cache": "^6.0.0",
-        "sparqlalgebrajs": "^3.0.0"
+        "@comunica/bus-hash-bindings": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@types/lru-cache": "^7.0.0",
+        "lru-cache": "^10.0.0",
+        "sparqlalgebrajs": "^4.2.0"
       },
       "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
+        "lru-cache": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+          "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw=="
         }
       }
     },
     "@comunica/actor-query-operation-service": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.22.3.tgz",
-      "integrity": "sha512-z+UUJjgYppnZwV+Oz3ZVQBZpLxUAFrAtvpuVSUmjJn6ab76X29ZQY13czY2y6TfiBhbbsW+HL5kuv0g3SEOHug==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-2.8.0.tgz",
+      "integrity": "sha512-9BNCoSEbzh08anvOKEXex1XgTacqFWXmxsKIeM+sr87/H7iS+UhWLcmyqYL9IrsjfkjMuWW6h+aNTVrqwJeAUA==",
       "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-slice": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.22.0.tgz",
-      "integrity": "sha512-BjanWrGY2EgH8nm5aEsYCLQIt4FZRYU9lQECdpihmVCloGX1ItzR5Rfk51tnGbXBarqm+pj6WoT+zSu0Ee4x2A==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-2.8.0.tgz",
+      "integrity": "sha512-BotGylGuWV8YuGeWaP8UpLekIEmQ/X+CebySORL+/U/+XULBDgyx7d6G0ThpUBG6p6YWyE9V6X4Bhx07EFqEjA==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-sparql-endpoint": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.22.2.tgz",
-      "integrity": "sha512-y+bnQlhTUtlybstinINiayQVXro9lZfpBiVBM9zxyZOST/fwXho5alclasfFgwy04js8aIM1efx8eJD2OUwlxQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-2.8.0.tgz",
+      "integrity": "sha512-cgogW7drbUiBffggtJT3ulDyQbfC0b0qpJ/Eb4sAMs0r/xYssK+BQejjJd5pfeunDPOve3v82yMAyso/mq8I8w==",
       "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/types": "^1.22.0",
-        "@comunica/utils-datasource": "^1.22.2",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/mediatortype-httprequests": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "arrayify-stream": "^1.0.0",
-        "asynciterator": "^3.2.0",
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "asynciterator": "^3.8.0",
+        "fetch-sparql-endpoint": "^3.3.3",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-union": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.22.0.tgz",
-      "integrity": "sha512-/qoweeCXg52ObfkFxjsU3nxsJBPavU6bCcDBJMLCFwd6VT9i7IKI+Y6aBH0CmCZpzBgaZQ1o3kGHJdUoxr+qyQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-2.8.0.tgz",
+      "integrity": "sha512-VB+1T+Q1VvPoO6GEWEstzlxALNCoreCo9UFp3c6fliNUTGvl1dIswGQUO05IJd447tGbe4jnNkgtB4Jz/dTLSg==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-update-add-rewrite": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-1.22.0.tgz",
-      "integrity": "sha512-4SBqqrsZBAwPJYoVr4w24D9NsAR48fQOUH6ZD05vyWG/vqedO2T2POFFNXBCCXiigr35QWvQLvbzoqamC5mbpg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-2.8.0.tgz",
+      "integrity": "sha512-12ul+wc6MQ+e4RPHNBj6jpsdkB791sckDZOZM8kZXQVPMlg+lFFrU5o2HQsk5oB8oHlwEMiGXXKBY/vig8zStg==",
       "requires": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-update-clear": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-1.22.0.tgz",
-      "integrity": "sha512-qRrUrkQJjvLv6PysbVJ1vOndHIvCHXpp5CmP1GFU4SF7s0LT65PSWh6+LgmcLKs+bntVMbdqaBu58lR5jk7J7Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-2.8.0.tgz",
+      "integrity": "sha512-Jfxys4fzl7NHb5zEwXaQuGa89kbWn9pRwv98qmDFdPyzWm71vh4/1yxVOyK579tifLFOtWzfAHPnnPrGAfkDgQ==",
       "requires": {
-        "rdf-data-factory": "^1.0.4"
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-update-compositeupdate": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-1.22.0.tgz",
-      "integrity": "sha512-rDt7JtQXOQ1LZY+xuhao6pv25zrXNH6VB8I6TlOAYm6OIE+PtAtbRp5AWzg8Yjqz81UHiXGQHV8SNx51LBkmtA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-2.8.0.tgz",
+      "integrity": "sha512-cIjX4ATSXqAVu63aqkOg9ON67Z+9jefVTy6Sk4ATymRewZmxoZG53krNpwAB6ox9NZ6QF5EfN3p3By5rJeG4Qw==",
       "requires": {
-        "@rdfjs/types": "*"
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-update-copy-rewrite": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-1.22.0.tgz",
-      "integrity": "sha512-WYapkqUcVZ8KWfSUlEz8iBg+OoRnHI3XvAlx6cyql4Fs/3l0Gqwc2PzWHi3N5J2AUsyiFJ28JrGDba8f1PYGLg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-2.8.0.tgz",
+      "integrity": "sha512-N2EpVCzwVBtcQmptjZ3+psRE0UNQUqQLln+1VOCE4dEfqAuQ47c2daBagHbIEVnSri1N/1rlxMRDPk+TcF/CAA==",
       "requires": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-update-create": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-1.22.0.tgz",
-      "integrity": "sha512-tZxqO+4n7qbDVJcp0VNYKRbI9uS8xTyK5s63sD53YeFl6Fl52dJtBb916R9Wb0pe2Pb37ErXF38/Z127P9EiNA==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-2.8.0.tgz",
+      "integrity": "sha512-usuaHdvEIqDa8BowmeAG7jfpTuy8wft199KOXUrxKfEIsUWppWeZS1TlfDLKIGdpAr/h+8rpl8wDcztMElzLKw==",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
     },
     "@comunica/actor-query-operation-update-deleteinsert": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-1.22.2.tgz",
-      "integrity": "sha512-8VGwvEEjHoEVwTJXGW4USHLS5DKc5iZwn1NByTAg8YdgX8ycE2odJi766cR8GLkeZu6621OUyZIgSnLdSAuMvA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-2.8.0.tgz",
+      "integrity": "sha512-beIFoi6J8hIP5nHcl/iFJqwa1bfLXMcbtHLphV3SyEd/UDr5a/hJct9oICUdMDbgm1MDUUhUUky3Rmwe2pWCTg==",
       "requires": {
-        "@comunica/actor-query-operation-construct": "^1.22.0",
+        "@comunica/actor-query-operation-construct": "^2.8.0",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-update-drop": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-1.22.0.tgz",
-      "integrity": "sha512-5DuDEmUrUO5vktgiDIHtBJtv0k1mHQqCQyF4nKLctq2bTDPaaYK533jqPM+ucxXINryx6t4SowUgdVRqpn4VIA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-2.8.0.tgz",
+      "integrity": "sha512-jhonibTxM/H9Psj0DfzH+VWkxzaPDvjJU9iHISezPOJl1hn+e+KrQ2RF3A8qqzKTsG3l/M9hgklZU4X1cVs66g==",
       "requires": {
-        "rdf-data-factory": "^1.0.4"
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-update-load": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-1.22.0.tgz",
-      "integrity": "sha512-nI4fMNGUevmprlTBgbuovJMQl+1LabCajvjC9ri5hZ9Ya0fEVQsFNbXH7H2oYlC0OOzM6uUjTdb9I8D/OzF8+g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-2.8.0.tgz",
+      "integrity": "sha512-tq973bYqQP2/ivNxBZgjYwVkroQfWA4pr3WMmSBF726OrwuQ5csqpHRrFy8JcsybAMgMTxpOp3CmZRUdUKmtyA==",
       "requires": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-update-move-rewrite": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-1.22.0.tgz",
-      "integrity": "sha512-ulo9KDuUy7555C0aOdgMUgOvCTLszJy8zLzN67HKktu1wK6WKV10zVMX/OcecdFE4fIVf/AA4SKXJCgsHGpXsQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-2.8.0.tgz",
+      "integrity": "sha512-bcKo6pZ/FtR6NfThBVaFuHh1WolGyR8MMWJfWKOUumcsxkHb5uzQ6V/hVk59Z/DFfSiuRuS1kDSWtv12RjT5Og==",
       "requires": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-query-operation-values": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.22.0.tgz",
-      "integrity": "sha512-P6znlDSYd6aD6NlSepc++V5HbmnNE8O4vZ8nvNmwZAS4z/pWjkaFM6eQkZPdkz+qXaGTzWHS3ib2zUDq3CaD4w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-2.8.0.tgz",
+      "integrity": "sha512-3c/by7iYOdXCqLreX6rBsIzNQFz6i6U1WMQnULWGvvuwMtqiTGd5GYhT+X6QMaqCk+1WNvG8F4hZNplAWE15Ig==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
-    "@comunica/actor-rdf-dereference-fallback": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-fallback/-/actor-rdf-dereference-fallback-1.22.2.tgz",
-      "integrity": "sha512-EzvBerax4WVOxmkRuHviehUQ3VUU0CPHV+fErFB9+s5UbXHk6MU3GqzH9iehoFYzpP7Xic0VZXFd34nCTvzmtg==",
-      "requires": {}
-    },
-    "@comunica/actor-rdf-dereference-file": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-file/-/actor-rdf-dereference-file-1.22.2.tgz",
-      "integrity": "sha512-KrjPfjdRQYVKyl7r8RiYK69HQ3f00f6RAc9BOhb0hlq/2PHtddAQ4oVNvs20PgHOKswsQsefd/HenLUhfa7+gw==",
-      "requires": {}
-    },
-    "@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.21.2.tgz",
-      "integrity": "sha512-TLQLw6rKkcslHyyYFpELy+Oc9KuLZbqxiOpMUQQqfi1/yLT/8C0dvQSTl0dOtKombSn4N3aFsA0ycbjuPWi01w==",
+    "@comunica/actor-query-parse-graphql": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-2.8.0.tgz",
+      "integrity": "sha512-yh+fqzNJE61weqfK1bbBXrGP650CE/VqPg10WaT6yO6+tlyYa3d42en5N/2TlqB8gVmCoYH4Ymz6GqSEJGHVPw==",
       "requires": {
-        "cross-fetch": "^3.0.5",
-        "relative-to-absolute-iri": "^1.0.5"
+        "@comunica/bus-query-parse": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "graphql-to-sparql": "^3.0.1"
       }
     },
-    "@comunica/actor-rdf-join-multi-smallest": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.22.0.tgz",
-      "integrity": "sha512-eoMuumFT+GB73f7H8Q8ijzchqHRY26w20lcKcsylC2bWS+ET8tFkYCODHop0uO53DMZPCrAm0C1higPB4XOw7Q==",
+    "@comunica/actor-query-parse-sparql": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-2.8.0.tgz",
+      "integrity": "sha512-jV2o/5gyx9K/vE8ceAddrrsjlDOWo0FsqPFVELBRyYxyoLn59gFNYk5iqLCCQYCmPda69mip1VwkCv6+J7EyVg==",
       "requires": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/mediatortype-iterations": "^1.22.0",
-        "@comunica/types": "^1.22.0"
+        "@comunica/bus-query-parse": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@types/sparqljs": "^3.1.3",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqljs": "^3.7.1"
       }
     },
-    "@comunica/actor-rdf-join-nestedloop": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.22.0.tgz",
-      "integrity": "sha512-8APKCtsH6lWmadCnp8xkJqu0O8uqBZ1GfFmV3KxmE3jPx9lrMVckmKBAd3i7vcMHWRwzOvZF4YFJkJxL7JeqnQ==",
+    "@comunica/actor-query-result-serialize-json": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-2.8.0.tgz",
+      "integrity": "sha512-Fgw/fRH12qr/gE5iEpAR7ttnAk6clHSEjbUqkAPswe+qkxALlMw7IfcyoTACQFP1WeSrs24udNXTjRjEDXCA+A==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "asyncjoin": "^1.0.3"
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "rdf-string": "^1.6.1",
+        "readable-stream": "^4.2.0"
       }
     },
-    "@comunica/actor-rdf-join-symmetrichash": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.22.0.tgz",
-      "integrity": "sha512-+K11crWY5N+Txb5HOP8P5/z2EN7WK8Cq1o1Go2RkUHhR0Pc4HZMoJtf6ATyJGB64y3lRpUVzKayrqSkDXlaSbQ==",
+    "@comunica/actor-query-result-serialize-rdf": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-2.8.0.tgz",
+      "integrity": "sha512-BP6umNugwjiUS2WfChkA5RfrubSlpjOXCQVmYkR6YA56ZjNfKNnZVZnkl9BQGd4cz5Wgd9n0IXuSq8mgx3UDEw==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "asyncjoin": "^1.0.3"
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/bus-rdf-serialize": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
       }
     },
-    "@comunica/actor-rdf-metadata-all": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.22.0.tgz",
-      "integrity": "sha512-8I7xrelM3G5nJ8SB5sh/cuIniAF0uDQ4AH8LA9z+aZQI5RvHN4kfgW6V/9NSmaEskyscy9m+nGkByEpuh+pHvQ==",
+    "@comunica/actor-query-result-serialize-simple": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-2.8.0.tgz",
+      "integrity": "sha512-vjjGWzEiVw9P+30c3gdJp2/Y+Qpq8U+UP2xFFbmbnGJ0kqQQUvxBNSZ9rwxm/j7hY28PMwV7ELEB1PODC90PYw==",
       "requires": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.3",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "@comunica/actor-query-result-serialize-sparql-csv": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-2.8.0.tgz",
+      "integrity": "sha512-EZw541247FBYqP3xrI4e3RDT2PEajlXK86EFHMyBeJGdzEuaRuVOEYtsdWS9KEzQdsoYbfIrdQSvTaf9LQSOaA==",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "@comunica/actor-query-result-serialize-sparql-json": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-2.8.0.tgz",
+      "integrity": "sha512-K3nQZB+JOlnEaRSSH+FJbZdOHriq+hcUnY0rwOiyk9L95MWrr70nCGBeSLlp4kJ84CxmavwA7w698HXAKGUTfw==",
+      "requires": {
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-http-invalidate": "^2.8.0",
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "@comunica/actor-query-result-serialize-sparql-tsv": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-2.8.0.tgz",
+      "integrity": "sha512-gKj+JehBXipvx9uz6zTUtxB/8REjEP7KCtA96et0qlM0vP6ZdKdav7jdvjG4443lWJyUKh2Nm+gxG3oXrwTzuQ==",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-string-ttl": "^1.3.2",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "@comunica/actor-query-result-serialize-sparql-xml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-2.8.0.tgz",
+      "integrity": "sha512-CoVrtlH0Emc6DaCPmcRLhASK5hh3SN/+3NHxpuTYJ6NtF7S8U7EtGzNi25dPgL0EYZM4Iql8r//Tnb+TaxS5TQ==",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "@comunica/actor-query-result-serialize-stats": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-2.8.0.tgz",
+      "integrity": "sha512-c0HhqLUl2gMG8Jvf/uGLQNy2dJQUPc6XsDZiwzskKjBrmjXk1bUKwQIy/sa0s7ch2VUGr8RjdmLEZw4Dsq3ZAQ==",
+      "requires": {
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-http-invalidate": "^2.8.0",
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "process": "^0.11.10",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "@comunica/actor-query-result-serialize-table": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-2.8.0.tgz",
+      "integrity": "sha512-XorIgM7nWYi9KNxkAv3wj8Wz7SUuYl4PHts1uRMetCUOgVRak2mR8IeUsY8LaGugBwLdvXXKxGOCkIZttX5Vkg==",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.3",
+        "rdf-terms": "^1.11.0",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "@comunica/actor-query-result-serialize-tree": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-2.8.0.tgz",
+      "integrity": "sha512-0HtJ831i1CWpBq8JBI/F+zUnEkGEvbYZj91CoaHFWbkLhjdmmENp25O3ro8jkkcJMKq910t7IzZbBzwCK0+8OQ==",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "readable-stream": "^4.2.0",
+        "sparqljson-to-tree": "^3.0.1"
+      }
+    },
+    "@comunica/actor-rdf-join-entries-sort-cardinality": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-2.8.0.tgz",
+      "integrity": "sha512-LmK1iqykzkX1C9LZ/BXQv318EbqFwnW3iymDYS3zOtkborB9QSdfjV9p/27mxGYjj2Ahv0zxQtU2G++gSfcKeg==",
+      "requires": {
+        "@comunica/bus-rdf-join-entries-sort": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-hash": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-2.8.0.tgz",
+      "integrity": "sha512-TXXeyVTFVKZttkrG2YZuDLHD+IodlDN7/uulxATkKk4t+XZu6k4n3cyibuyhQ1oq3ftVYokejijfTWCkNLvcYA==",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-multi-bind": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-2.8.0.tgz",
+      "integrity": "sha512-lwGQ3MTd5MgNps+lsAV2otaC5SpfGPSYkJTHQnEuQsB/Nr1ikXZqrAV0xt7Z/tfXDp9QSqn4C/EbVq4oogpU5Q==",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/bus-rdf-join-entries-sort": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-multi-empty": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-2.8.0.tgz",
+      "integrity": "sha512-SCJqhN2a4Abs5KC6woNHiT/rORlUdeYrkNn/VRUzPsr9L7DB9lnOus7H1OBUCh2MZPZgKZqqj0YXeekEDrbfWQ==",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asynciterator": "^3.8.0"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-multi-smallest": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-2.8.0.tgz",
+      "integrity": "sha512-YtiJ88FEVY9+RZtG8J/EQtQldJch31Z3/G6RaAUmG5HM97aV/Nk3BCoqtGcWahFwnOPxfbmdMhgXfvLA8Wc9Eg==",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/bus-rdf-join-entries-sort": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-nestedloop": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-2.8.0.tgz",
+      "integrity": "sha512-2iw5v0kWnRsrGsyzUgDvGcfhnKNLAAkTk+DJ1zeVJJgNjeRWbxrxyOwHyySxz66KOxw9saylUVDOxqrWsZkgiw==",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-none": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-2.8.0.tgz",
+      "integrity": "sha512-ItujqMqGpJ7tBH4/7inzBWCgm6O6IjXw4CSfMcd8sX2XlPWt3Kh8rNgp6zZtIHAm90q9us0pZZqTuxt0U8LtDw==",
+      "requires": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "asynciterator": "^3.8.0"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-single": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-2.8.0.tgz",
+      "integrity": "sha512-+CN4dJhJYFJMmLLkLaQOE26qVigYhVhqGa+DFB5B6liR9bKHDEytktOSgSwaBR2oPUifjT7eGshDj9ZdmbB3dg==",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-symmetrichash": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-2.8.0.tgz",
+      "integrity": "sha512-vuWbVsWKshBExfOor1yIeNmxqdBHZZmMndMjyj5acRX/QIWNb2XS17HcTP1z0BC22yvl4vm3HyvZ6ksbOTKJLA==",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "@comunica/actor-rdf-join-minus-hash": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-2.8.0.tgz",
+      "integrity": "sha512-5lkzyk/jhkusyCltnyR7u17qS3roB9Fr6L3W/3Vbmmv6HbwlA2FvJ/qy5+8jX2wn7rWAb8bGRJdHi4BiOnFHFw==",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*"
       }
     },
-    "@comunica/actor-rdf-metadata-extract-hydra-controls": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.22.0.tgz",
-      "integrity": "sha512-fSYye14RuiT0H9il92G8bDUuOrRxRY1is/+C+ShAXb6npx05GDfO+p9Ew4hBCRbveU10DAdsarOTYpcP2bTZSQ==",
+    "@comunica/actor-rdf-join-minus-hash-undef": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash-undef/-/actor-rdf-join-minus-hash-undef-2.8.0.tgz",
+      "integrity": "sha512-C3sqL4mWcAozLUKHXTPD9gsdePVnYwze1s1Tn4KKHv1FBurckcV/jGCUgavyK4Bh2yURXzSA3yXgYyz5LQraWw==",
       "requires": {
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "@comunica/actor-rdf-join-optional-bind": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-2.8.0.tgz",
+      "integrity": "sha512-JOPDu2nFpYeBy8xL3pSaDIUawykYmQaYFRbVLnVAFJc+bx5VE6WbH5s7kCwfOBYGCYNDa7xrauC3Dv2Vg55KVA==",
+      "requires": {
+        "@comunica/actor-rdf-join-inner-multi-bind": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "@comunica/actor-rdf-join-optional-nestedloop": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-2.8.0.tgz",
+      "integrity": "sha512-LXYK6iQgdT3rGB0OD17DdQTNX2VkiImzHAU6GHswdPqOrEzlPtveDSueaFfte8B30znQymV53LLLtMxvnPUk+w==",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "@comunica/actor-rdf-join-selectivity-variable-counting": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-2.8.0.tgz",
+      "integrity": "sha512-cSJgvxGxwqlueDqBhzDd/NNysq2TgfIalwWMP3BxZXTshHN+bhfaGEZr7Jp/NRG3zPbnadWS+pqaRFCSmir6nQ==",
+      "requires": {
+        "@comunica/bus-rdf-join-selectivity": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/mediatortype-accuracy": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-accumulate-cancontainundefs": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cancontainundefs/-/actor-rdf-metadata-accumulate-cancontainundefs-2.8.0.tgz",
+      "integrity": "sha512-s8zPBHiUIHQ4Ofsnip/mb9Fqg22mJvB9A6slch5z7whkWYVk+RLSQLxEQVjhb4/9cb6Bq6jof5mnQKYwUKbRKA==",
+      "requires": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-accumulate-cardinality": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-2.8.0.tgz",
+      "integrity": "sha512-9SnfQjU0yfw1QNf721ygevNP3ElTFK3+YwQgmGHdh5Qx2UE9zCwHYO6tPb55y10rVEwiMojC/rLY3KDLEVu2mA==",
+      "requires": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-accumulate-pagesize": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-2.8.0.tgz",
+      "integrity": "sha512-1gycVMGGTvRGmOl8Z+9CBFaMVDfkcm5VwmO1WRbfqfoWAdvMYjMk0DOQ8mFbK+Z40ez9LQ8rJh6EyNTVMM3rgg==",
+      "requires": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-accumulate-requesttime": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-2.8.0.tgz",
+      "integrity": "sha512-iZTGdAxUU2fIImuRs4UQVYXzukMavyfM+ThTHSPv88/jh1AmmPh6eVc+zrUuIZhP6rGpoVRBLA9ObfinzGM2Mg==",
+      "requires": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-all": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-2.8.0.tgz",
+      "integrity": "sha512-GTzaNGQS9SaexmWsxWhqSfVLKHCKL/X8W8tXBMxgwBt29NtPGPqM/7avZJ2MI3zhvkvum7OjlWR4E7deNHhLUA==",
+      "requires": {
+        "@comunica/bus-rdf-metadata": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-allow-http-methods": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-2.8.0.tgz",
+      "integrity": "sha512-3YBQ4473M3SicJYtq1IqBCqGqMQ+/r2Qv1EqJWf57u41AROULxB+7M2eerJe5mtZEvD1NYhaxJ3oBX97iVTXvQ==",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-hydra-controls": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-2.8.0.tgz",
+      "integrity": "sha512-QQrv/6Gi910rPgk725nwt/NcViGKIA7Br3UfovraRQKOlNKT6qH4/CJxRKHvy5l9gbvaWW/1hrOYhO835H7eUQ==",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0",
         "@rdfjs/types": "*",
         "@types/uritemplate": "^0.3.4",
         "uritemplate": "0.3.4"
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-count": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.22.0.tgz",
-      "integrity": "sha512-IM27SyFT2lRZc853m10I8YQX+nzSS5ouY4dLWyI3yzlYfI1LFOI/kDiUicgiyAoAy7UBG2c60jvFXTC6HQsdJw==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-2.8.0.tgz",
+      "integrity": "sha512-mD+hO98676rG63BLMDOibtgDSYkT77aEzWEllsijnnNkQhe29PRH27DhEBbOPgAoFYIYmdzaGw9X+rVI0b63UA==",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-hydra-pagesize": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-2.8.0.tgz",
+      "integrity": "sha512-pAnV5Ddb4ouN+R1cTxFIfWqPxMgofC/zqlwrX515/oKihwttWIHlBXFBdDNG0+yw4fdLUCWW5Usw7CTiTihAYg==",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
     },
     "@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-1.22.2.tgz",
-      "integrity": "sha512-de9IJPIuXrvh8plhl8RndrbNcigO7hhi34bEoKwcjdX8YBK1F4BEK3mRvE0rlSjwv5vDLPjT4ejxl6bL2Da/rQ==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-2.8.0.tgz",
+      "integrity": "sha512-VaGD7VH51O9smipmWHVf2xqDy8+2/kyIoX5E6q6oCP1sZVrrwY1Tz8oK0dCS1FamwzlQGUMwj5XW5sXVWRMvsg==",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-put-accepted": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-2.8.0.tgz",
+      "integrity": "sha512-VMxzAVtNP4iiKH58NFsxo4O3I6N645jg8TAEv/F/iMK71IzxSxBBNv9dTUMc3EpXqB2USJPor22WzKN6xa5+xQ==",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-request-time": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-2.8.0.tgz",
+      "integrity": "sha512-w/9uBJd0BJsqJHVuPQVl5BrZ3SPKQcPVXQ6kgpBJBv2i9vo0oJSakp3ISivGYzCG/CtvdDupUc5dNhXD8qwckw==",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
     },
     "@comunica/actor-rdf-metadata-extract-sparql-service": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.22.0.tgz",
-      "integrity": "sha512-z2w/bhFZ/iWq7KgdLqBD/8CWL7S9VZJSmczccgKmwQGRJWzJ4mHpUAdOCh7EFD/9HbsC4fXJGXZHQjZ8u6SM6g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-2.8.0.tgz",
+      "integrity": "sha512-m1PjQ+fiQq7h982daEA2jVdj3OEypy8mavM4GsfkED+9kAtycTJeFaa8FTjFacfp36EKP4K/BWh0FsvRhAY5Ig==",
       "requires": {
-        "relative-to-absolute-iri": "^1.0.5"
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "relative-to-absolute-iri": "^1.0.7"
       }
     },
     "@comunica/actor-rdf-metadata-primary-topic": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.22.0.tgz",
-      "integrity": "sha512-+ZRSUVDqUZo5RLwOUbtIifiBn2Qgg6awMsfRlw2PeGE72BhQ1ik0tfz1l9Q7UuYnxnLoUFe2zyKEYc7GXAV34g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-2.8.0.tgz",
+      "integrity": "sha512-NuD7rMBif6rZkd/XyPolIKtkAEZ5gi6WmbTYur+4X2UaO20MWK5b+28nsN35OvUVQ0OiCuiLtrlZtRP5AjpOkA==",
       "requires": {
-        "@rdfjs/types": "*"
+        "@comunica/bus-rdf-metadata": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.2.0"
       }
     },
     "@comunica/actor-rdf-parse-html": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.22.0.tgz",
-      "integrity": "sha512-U9pznSpQ1POSH+ekOke3lYKO0fsUbNdv1g1nfuWz/MV3xMCF/d2f3CVBjXRSx9qwyb/2zUrOjBCJRrYkfZ6geQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.8.0.tgz",
+      "integrity": "sha512-/GJoBkHAJRdMx/VnVulutuTrKOy4Z26SzqlvUFsWyLzWoee8MT9izltG3QO1huHvbj0gePdczPGxtMt3rVihNw==",
       "requires": {
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/bus-rdf-parse-html": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "htmlparser2": "^7.0.0"
+        "htmlparser2": "^9.0.0",
+        "readable-stream": "^4.2.0"
       }
     },
     "@comunica/actor-rdf-parse-html-microdata": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-1.22.0.tgz",
-      "integrity": "sha512-OdB3Z7ZCtVAcsVU2Vs0ytGbiz0eYkeBwVA3k0vGVhSN3ygng5Thj+t8jxG6QWHlLvaIXfJFh0x57qY5tXkr8uQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.8.0.tgz",
+      "integrity": "sha512-NOvEwrM0didm8caSM7QWbm5WFYu4beMhf5WLzX4yaCmm7r5hK/ObP2EVVripSUw/CKu0PZbgWVmZAdR1H4qlPg==",
       "requires": {
-        "microdata-rdf-streaming-parser": "^1.2.0"
+        "@comunica/bus-rdf-parse-html": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "microdata-rdf-streaming-parser": "^2.0.1"
       }
     },
     "@comunica/actor-rdf-parse-html-rdfa": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.22.0.tgz",
-      "integrity": "sha512-yVjYLpm9rbpPiqU1OE4Yioyk/YHtO6ywVMbdOPUNLeOwrtWou8vKX0Xh4UUR24Qrt8nuhE+p0kCJiZZtM1PmSQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.8.0.tgz",
+      "integrity": "sha512-KY7DI2OChT8rFFXtUWccPc7nSyhsM5xjIlQnumpBWpF9Px/ah2djVIe0hPcoJnrhlIqjCtal6yEUHItRaX8ERg==",
       "requires": {
-        "rdfa-streaming-parser": "^1.5.0"
+        "@comunica/bus-rdf-parse-html": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "rdfa-streaming-parser": "^2.0.1"
       }
     },
     "@comunica/actor-rdf-parse-html-script": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.22.0.tgz",
-      "integrity": "sha512-gQSY56wkS/uftRyjQf+/dQFRpA/jZ6z2o2RgGbQc2avgKTkhaiTtPxpfO1oarLskm1sPlQOFo24ZwqUSqjOwcA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.8.0.tgz",
+      "integrity": "sha512-JnriW7bTOvWtbgkwPsCjr6sQKfEk1ms4uR4cB1ril5md3Grn7CquTDz1keT5Yb12qO0gRF4pJbV0Aw02TWkcug==",
       "requires": {
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/bus-rdf-parse-html": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "relative-to-absolute-iri": "^1.0.5"
+        "readable-stream": "^4.2.0",
+        "relative-to-absolute-iri": "^1.0.7"
       }
     },
     "@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.21.2.tgz",
-      "integrity": "sha512-YUiYo2EJ9T1oUGgBwzzPRjXT+cd/xckWbtfYBzr7RugXeKjrVai8atnV1OsPc0u5iPZCTkiVCO9sI/Q6M7ig2w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.8.0.tgz",
+      "integrity": "sha512-b9RYIsUYG+9wUOWeapfc0G8U+pHzv4AyJaEHjlf2S3XHxd3O3GfwCxc7532NHURG94sIu+uWDvwjUtS9PUa/NA==",
       "requires": {
-        "@comunica/context-entries": "^1.21.1",
-        "@types/rdf-js": "*",
-        "jsonld-context-parser": "^2.1.2",
-        "jsonld-streaming-parser": "^2.3.2",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "jsonld-context-parser": "^2.2.2",
+        "jsonld-streaming-parser": "^3.0.1",
         "stream-to-string": "^1.2.0"
       }
     },
     "@comunica/actor-rdf-parse-n3": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.21.1.tgz",
-      "integrity": "sha512-SFx/hkY0yr/TxfVdEecVg3DY2KOWPeGfM288CjDQjogx6Sxb6JuF9JaipNX8/twKVdBefGS9b1S9EyKpcr99Zg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.8.0.tgz",
+      "integrity": "sha512-VCwmD1mpgiD3jQ8g6DF09VMFWSWxOKWfQ1mtLx64Oy+czTyz6tgT4n6w+cyIFFzFtDDoVgX1hknrCODU1kX0vw==",
       "requires": {
-        "@types/n3": "^1.4.4",
-        "n3": "^1.6.3"
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "n3": "^1.17.0"
       }
     },
     "@comunica/actor-rdf-parse-rdfxml": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.22.0.tgz",
-      "integrity": "sha512-k47WEAZ6qKEhf1eBZZeI5aVywlrUUKP3BKHw2zKJUjuWq5k+w/rp2WALCyt0Owtb37UlJbET3fTlUhXKvT+2aw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.8.0.tgz",
+      "integrity": "sha512-slefbVFQFNdikRcjnrRMHxsbXznHiQvOg4nQNA310t4Q4NSegfePI/6I06kTJ4/SvkGtWgsFoYIsHINuOvqqVg==",
       "requires": {
-        "rdfxml-streaming-parser": "^1.5.0"
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "rdfxml-streaming-parser": "^2.2.3"
+      }
+    },
+    "@comunica/actor-rdf-parse-shaclc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-2.8.0.tgz",
+      "integrity": "sha512-+R/h9GUoFXcZ2S3Ku1PrSAdYRVHjws3eE0Go4m2CFiBswW783/1lwKDx0FLO4xGO9ixw+EgstmciirTj5O9nTQ==",
+      "requires": {
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "readable-stream": "^4.2.0",
+        "shaclc-parse": "^1.4.0",
+        "stream-to-string": "^1.2.0"
       }
     },
     "@comunica/actor-rdf-parse-xml-rdfa": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.22.0.tgz",
-      "integrity": "sha512-y315YcZTz7AizKf8Jl022IocAJIh3OHSlzNrRNH3zB7i/ch+WHj1VL9pjIf6y77PD4BR75EdeoQCPafpm5Gsbg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.8.0.tgz",
+      "integrity": "sha512-+Xg6WKWjLTYysogw5x1Savyt3ZFYDmmIhPyMpAyNqfFplHZC3QoON0kKitZ81SC7fiTRpwcyDLYC6DkKBH7DxQ==",
       "requires": {
-        "rdfa-streaming-parser": "^1.5.0"
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "rdfa-streaming-parser": "^2.0.1"
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-links-next": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.22.0.tgz",
-      "integrity": "sha512-94t3u2B2kH8ftMtkLfo1B/v1SJkiFdEf3y351UOqrWJ71GNMQwgvzQFcSRL4QRcgaIjz4wecj8oGUN0wPs2Kdg==",
-      "requires": {}
-    },
-    "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-1.22.0.tgz",
-      "integrity": "sha512-DzQgHFDDXtawPvNbei1j6xL2yWdlSpq/vOD4K8Z+NrheKjNbPz84bJp0bhnWiOonwHMCRdxQRu+Etf33SFWFJQ==",
-      "requires": {}
-    },
-    "@comunica/actor-rdf-resolve-hypermedia-none": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.22.0.tgz",
-      "integrity": "sha512-rPtjD7WAlXBwrWmG5vy9hGo5J9AlKaWuH7Cf3I0HFUnPRegF98UAFZyygQP4otDC3EsygJakbmApBkzjiKFRPw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-2.8.0.tgz",
+      "integrity": "sha512-IcDuQjO6HwwOmM1aEYpeX4UcVcZ5wM2wSkyobFsicMQWM41mlDxwwXqYJqS1TcbW6TqOEzGBStSUEYlyyN9+uA==",
       "requires": {
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-store-stream": "^1.3.0"
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.8.0",
+        "@comunica/core": "^2.8.0"
       }
     },
-    "@comunica/actor-rdf-resolve-hypermedia-qpf": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.22.2.tgz",
-      "integrity": "sha512-dHR6FtLj/buvHmOT9B0FysWwIQO7L0+uqCnHQ9peShKOwpKMtl5qW9a8L63yWNlB34JgB+ZvL0/qJO7JWZZXTQ==",
+    "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-2.8.0.tgz",
+      "integrity": "sha512-nvgTKJc6T0USuPbvB8nfc9tzqy4fNKAedgbsIso1B9yYr7gfH0ypA0Lbc5l+GBiiOaNjQskyAit4zFF6Nz55Pg==",
       "requires": {
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2"
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-none": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-2.8.0.tgz",
+      "integrity": "sha512-K1TBuH84CPjShDRa58pqthagno8DcAARlkmN/08U4s2AdojR/Hc2kxMdeXym4vLCWxfw/7GVYglNmpDlYN6vTg==",
+      "requires": {
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.8.0",
+        "rdf-store-stream": "^2.0.0"
       },
       "dependencies": {
-        "@comunica/bus-rdf-dereference": {
-          "version": "1.22.2",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.22.2.tgz",
-          "integrity": "sha512-dtLEmCzlscpe8AqEver8H+7a7UzyOXslUQ00VE+igt/+oAQvJpRBCQ3yB6XkyjAV/+ApLrbAjpCRf3Gp2NWfgg==",
+        "rdf-store-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-2.0.0.tgz",
+          "integrity": "sha512-FKRsA5XUdhFVMx+jg4JCBM76B4ZcXVKyilr8GJrlfkHB2IZSIgLxY2XHIsewkDfm/yAtXHvPT0PaeQg4Mbqa6g==",
           "requires": {
-            "@comunica/context-entries": "^1.22.0",
-            "@rdfjs/types": "*"
+            "@rdfjs/types": "*",
+            "rdf-stores": "^1.0.0"
           }
         }
       }
     },
-    "@comunica/actor-rdf-resolve-hypermedia-sparql": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.22.1.tgz",
-      "integrity": "sha512-nbvGfhHKyPBygeQyxLyUyrQen7q3JrSJi92x8TrkhUoTxiEYM0bYUvYmsciqlxLhNxH7EPpMzzf1oaiZfiqlqA==",
+    "@comunica/actor-rdf-resolve-hypermedia-qpf": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-2.8.0.tgz",
+      "integrity": "sha512-3I4VVfnpnL5rnP5b8LMXdD4o9+mRCzhUdT0arhBc2noUvqhC2QX7bbLXojPC/2/DyHGIWhYA9kZx+j77e5j5Hw==",
       "requires": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/types": "^1.22.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.8.0",
+        "@comunica/bus-dereference-rdf": "^2.8.0",
+        "@comunica/bus-rdf-metadata": "^2.8.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1",
+        "rdf-terms": "^1.11.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-sparql": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-2.8.0.tgz",
+      "integrity": "sha512-OBlLDNeLG8BD3gdHEmzryhiOBU5/ylTPFLG9CwFDh3NFpHhqoyT0YB0QLrpyp/hg4U22qMtRkt6enasycHsIRA==",
+      "requires": {
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "fetch-sparql-endpoint": "^3.3.3",
+        "lru-cache": "^10.0.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
       },
       "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
+        "lru-cache": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+          "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw=="
         }
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-federated": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.22.0.tgz",
-      "integrity": "sha512-Cpt5LvusDUK/mnA2LlcuQ3hqpJp9CSDjd0c7NESWuR2uCXDAxugWVJAll0EosIAw0Lx82n0SneOBqh6pk2gPxQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-2.8.0.tgz",
+      "integrity": "sha512-bQkA3PfYXtpUlq5+y0wgYtMRhztp52lSq7riSQZHnmMtkbl39YCNXk15c0aKj03Ec0uz/ujnf+oO0rBPz7/U3g==",
       "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/data-factory": "^1.22.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-metadata-accumulate": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/data-factory": "^2.7.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.22.2.tgz",
-      "integrity": "sha512-eQhXoOYVpEJNkp6pYvJwaU+PmvR41VEKX9zivcBxRGagbLOaX5SG0xV+0I2YApB4HvagD/0IICVRRxXqODRUVA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-2.8.0.tgz",
+      "integrity": "sha512-9x4nuWbvilwsapeAZS+bV4NJOSUO0qYh7HP8tEloD+UcqLOsu4KGhBkGYfx7nZC96FaManbxuuH63BCHRYI/jQ==",
       "requires": {
-        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.22.0",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@comunica/utils-datasource": "^1.22.2",
+        "@comunica/bus-dereference-rdf": "^2.8.0",
+        "@comunica/bus-http-invalidate": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-metadata": "^2.8.0",
+        "@comunica/bus-rdf-metadata-accumulate": "^2.8.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.8.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "@types/lru-cache": "^5.1.0",
-        "asynciterator": "^3.2.0",
-        "lru-cache": "^6.0.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
+        "@types/lru-cache": "^7.0.0",
+        "asynciterator": "^3.8.0",
+        "lru-cache": "^10.0.0",
+        "rdf-streaming-store": "^1.1.0",
+        "readable-stream": "^4.2.0",
+        "sparqlalgebrajs": "^4.2.0"
       },
       "dependencies": {
-        "@comunica/bus-rdf-metadata-extract": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.22.0.tgz",
-          "integrity": "sha512-u7YXAKh3jXbPBE1ATciwwdYjwi8BNDi6hkRYxszD+IKJeW6x62VXiw24sraR3mvJohl3a2tR9nQHWv9Khijisg==",
-          "requires": {
-            "@comunica/types": "^1.22.0",
-            "@rdfjs/types": "*",
-            "graphql-ld": "^1.4.0",
-            "rdf-store-stream": "^1.3.0",
-            "sparqlalgebrajs": "^3.0.0",
-            "stream-to-string": "^1.2.0"
-          }
-        },
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
+        "lru-cache": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+          "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw=="
         }
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.22.0.tgz",
-      "integrity": "sha512-iy7PQav5pytbtHfU7EjP9NTKRXEKNez7tZfoI6FwGVIreX0WrxpE100xCjhQt0kkkEb7l0R0Yn6n9cXsJc8Gcg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-2.8.0.tgz",
+      "integrity": "sha512-UqijQFYcUfxekgU37lhUtcTftVHDTBJwBIBTGJS7rZF/2ti45bwOK3ogN+1Wtkfb1r07Ti87ZJhZE5hExRaEmA==",
       "requires": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-terms": "^1.11.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-string-source": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-string-source/-/actor-rdf-resolve-quad-pattern-string-source-2.8.0.tgz",
+      "integrity": "sha512-H3NSj1iXGlWPCua1wMTYMsUcjafn+Y2+hOAPnaCDaN2ctcqoStPct7yg/DZv/dqSlqq1Xwb5hcyVu+Afw5XRRw==",
+      "requires": {
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "lru-cache": "^10.0.0",
+        "rdf-store-stream": "^2.0.0",
+        "readable-stream": "^4.2.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+          "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw=="
+        },
+        "rdf-store-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-2.0.0.tgz",
+          "integrity": "sha512-FKRsA5XUdhFVMx+jg4JCBM76B4ZcXVKyilr8GJrlfkHB2IZSIgLxY2XHIsewkDfm/yAtXHvPT0PaeQg4Mbqa6g==",
+          "requires": {
+            "@rdfjs/types": "*",
+            "rdf-stores": "^1.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-serialize-jsonld": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.22.0.tgz",
-      "integrity": "sha512-UrkVEkeY2Oobsjw0kiswtTNcJU9ePXlekFE0iyemZs7b3DLAibzQeMERTiY2lSV+NBwpGhKAR+6DkCjLjd/TOA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.8.0.tgz",
+      "integrity": "sha512-qmmt/WWlMFzrHIAghGSrq2wtNwQ8FUHJZw+l/PGJ2f0GbasDJECPWieYPJweHztOOTZ962hsjpjaiaDGMbGV8A==",
       "requires": {
-        "jsonld-streaming-serializer": "^1.3.0"
+        "@comunica/bus-rdf-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "jsonld-streaming-serializer": "^2.1.0"
       }
     },
     "@comunica/actor-rdf-serialize-n3": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.22.0.tgz",
-      "integrity": "sha512-9LBLd+ayFn7Rb/ASt1ZrBjjsUZV9I01E7MB19mcz3pyCt1HZdQ0l8JeZ5gC18cOK5B/X1KKZsx2wP+ZpHwa/og==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.8.0.tgz",
+      "integrity": "sha512-u6fRZI4K8w+kFqM4jvOe0egVHWavJQ15mk/+0ddLNWem21ETSXY5wkeEauFBKUj21/Buzr8wzp0d8RuG/+L2BQ==",
       "requires": {
-        "@rdfjs/types": "*",
-        "@types/n3": "^1.4.4",
-        "n3": "^1.6.3",
-        "rdf-string": "^1.5.0"
+        "@comunica/bus-rdf-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "n3": "^1.17.0"
+      }
+    },
+    "@comunica/actor-rdf-serialize-shaclc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-2.8.0.tgz",
+      "integrity": "sha512-SOoYVxjuf0sCv8MRli8mpgvawJW4dd5CymPgcOE9hh8HcRluMwgCYAUB96B9+4g1MwCirc2LuR9LNqhKZGnFhA==",
+      "requires": {
+        "@comunica/bus-rdf-serialize": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "arrayify-stream": "^2.0.1",
+        "readable-stream": "^4.3.0",
+        "shaclc-write": "^1.4.2"
       }
     },
     "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-1.22.2.tgz",
-      "integrity": "sha512-CqaDel2GTxYcM9CVzMERaGlA6XVWbqjkAfvnufhl9suMiDw8aqnuw91sPMbTlh38MhAaLY6SVwmxqekmdtxOhg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-2.8.0.tgz",
+      "integrity": "sha512-yvMk66avpqtuEHl9fvz/HUWvN/f4GHcXLCsrH4WZxUsaLnFBfgO1jTRgAWmqGUG3afPcWhEwLaR2wQszLKslZw==",
       "requires": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "cross-fetch": "^3.0.5",
-        "rdf-string-ttl": "^1.1.0"
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "cross-fetch": "^3.1.5",
+        "rdf-string-ttl": "^1.3.2",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "@comunica/actor-rdf-update-hypermedia-put-ldp": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-2.8.0.tgz",
+      "integrity": "sha512-dxc769C15b7sVQ+7gFfrcVCLbnYTBh06gU+sU6QO2SPciVRBCk4J+W5BRGN6vED87FZWmQHdmvgpfhoFmuhz1g==",
+      "requires": {
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-rdf-serialize": "^2.8.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "@comunica/actor-rdf-update-hypermedia-sparql": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-2.8.0.tgz",
+      "integrity": "sha512-RxVXrwyfsdJyEXGMdLg1ZunGgdu3HvSkiYazVzHwjTgSoWQ8J1M6sVe8ApMJIBJoK03KLoFupvnHmVF5sh+PQQ==",
+      "requires": {
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "fetch-sparql-endpoint": "^3.3.2",
+        "rdf-string-ttl": "^1.3.2",
+        "stream-to-string": "^1.2.0"
       }
     },
     "@comunica/actor-rdf-update-quads-hypermedia": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-1.22.2.tgz",
-      "integrity": "sha512-e6kbJTIo92ig4LxdgQTGHcXp3PjHjdWWqOpVDO6Um5S/hoYRWZLA5/KI9BAxIodyaMaYU+gfSymkVfSNPrJjmw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-2.8.0.tgz",
+      "integrity": "sha512-D9q7GyR7p182nuPGnijJVyZCJkkE9tTxicUgK58k6t88t11qbfjxe6RXz0SabmwjEshX+6/mHkQy9MQFC6YhBQ==",
       "requires": {
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.22.2",
-        "@types/lru-cache": "^5.1.0",
-        "lru-cache": "^6.0.0"
+        "@comunica/bus-dereference-rdf": "^2.8.0",
+        "@comunica/bus-http-invalidate": "^2.8.0",
+        "@comunica/bus-rdf-metadata": "^2.8.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.8.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.8.0",
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@types/lru-cache": "^7.0.0",
+        "lru-cache": "^10.0.0"
       },
       "dependencies": {
-        "@comunica/bus-rdf-dereference": {
-          "version": "1.22.2",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.22.2.tgz",
-          "integrity": "sha512-dtLEmCzlscpe8AqEver8H+7a7UzyOXslUQ00VE+igt/+oAQvJpRBCQ3yB6XkyjAV/+ApLrbAjpCRf3Gp2NWfgg==",
-          "requires": {
-            "@comunica/context-entries": "^1.22.0",
-            "@rdfjs/types": "*"
-          }
-        },
-        "@comunica/bus-rdf-metadata-extract": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.22.0.tgz",
-          "integrity": "sha512-u7YXAKh3jXbPBE1ATciwwdYjwi8BNDi6hkRYxszD+IKJeW6x62VXiw24sraR3mvJohl3a2tR9nQHWv9Khijisg==",
-          "requires": {
-            "@comunica/types": "^1.22.0",
-            "@rdfjs/types": "*",
-            "graphql-ld": "^1.4.0",
-            "rdf-store-stream": "^1.3.0",
-            "sparqlalgebrajs": "^3.0.0",
-            "stream-to-string": "^1.2.0"
-          }
-        },
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
+        "lru-cache": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+          "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw=="
         }
       }
     },
     "@comunica/actor-rdf-update-quads-rdfjs-store": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-1.22.2.tgz",
-      "integrity": "sha512-veMjUWILDYzsvETvlGjFN14w5zNTAZlbFr7vmm6F4zuI5m5G4wnVHrdhU1cf7wp3foGVDOzp5jIC9Hl3UMKtCQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-2.8.0.tgz",
+      "integrity": "sha512-TJICnRea5PQvgQXwN0r4k9IHjSveHE12Xziqwwsn0Y5iECoplCE/yJdpq1JyVQam+3nlSm/dvmdOa8ySR54n2A==",
+      "requires": {
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "@comunica/bindings-factory": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bindings-factory/-/bindings-factory-2.7.0.tgz",
+      "integrity": "sha512-NeLbBmqiNhyUCZSfqZfwZD50dQ5+DABgPbzfuZnbHq9uSfhxAzuGCzgrK0hmuwRHWOPBtmeRnyZTJorePuxTzQ==",
       "requires": {
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.4",
-        "rdf-string": "^1.5.0"
-      }
-    },
-    "@comunica/actor-sparql-parse-algebra": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.22.0.tgz",
-      "integrity": "sha512-8XdAbj0zd2O+2dE/i+J/mdL6xAK8qYcQ6xFf61SmIPIQBxdSRmlqxKfIc+qdCp8/KyEEG/ePA6+nG0rb94nqfw==",
-      "requires": {
-        "@types/sparqljs": "^3.0.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqljs": "^3.4.1"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
-      }
-    },
-    "@comunica/actor-sparql-parse-graphql": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.22.0.tgz",
-      "integrity": "sha512-tbN2Vh1y+XwvkKP+6Pshq89Enr/aWmG9qJH7WKdu25GqJRN9yydk3NVHJBwGpesydtRKlgFN/UrYuM7FCls8MQ==",
-      "requires": {
-        "graphql-to-sparql": "^2.4.0"
-      }
-    },
-    "@comunica/actor-sparql-serialize-json": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.22.0.tgz",
-      "integrity": "sha512-DFFBGoQxvGHtE6t9/5vsIABUakFLok1l4FSx97fhQ3551+LiosWBbjFpswFwEr0AGKHJPEDH4qYe0gvVuUqq+w==",
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-string": "^1.5.0"
-      }
-    },
-    "@comunica/actor-sparql-serialize-rdf": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.22.0.tgz",
-      "integrity": "sha512-OMe31+egTtd7aSTi1bu3ufsNXjJDNPQ/5glxGCzPb0ZxC+lE4LMdGtMZ3mpfLy8mzEQCrMXGZboCyv1K7I9EAw==",
-      "requires": {
-        "@comunica/types": "^1.22.0"
-      }
-    },
-    "@comunica/actor-sparql-serialize-simple": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.22.0.tgz",
-      "integrity": "sha512-wkoQz+xyd7FA00C0T70ochP3UOW4TrYpxBLbnqPkm7Iw8pFEn1iJ8ta12SNuju/lVtqfN+e16CFD0OlaGgCEZA==",
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/actor-sparql-serialize-sparql-csv": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-csv/-/actor-sparql-serialize-sparql-csv-1.22.0.tgz",
-      "integrity": "sha512-dXlNRulCZRCtf+GamYrBsR4bAbLZvcFPZp1WsbuGhCygqitu2QLwTlSMphgOtyuOCPEeF8Y6+1yljqoTC58WMA==",
-      "requires": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/actor-sparql-serialize-sparql-json": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.22.0.tgz",
-      "integrity": "sha512-bFQX/a/lAv4akO7/8xMM/lbr2ZZbSPb4byo4TlSDLihnOeB8sEXb8hBPHqHoN57faxUUqzBEy4zzx4cdcXHM4g==",
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/actor-sparql-serialize-sparql-tsv": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-tsv/-/actor-sparql-serialize-sparql-tsv-1.22.0.tgz",
-      "integrity": "sha512-a/zZDura9tu0g6wP/Z1+/RUT1zKJICjeC5azOX6BOSTdt6N+ldNrB06tyRyIbPyAGSAK0t+tOgiUPWanjXXUng==",
-      "requires": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-string-ttl": "^1.1.0"
-      }
-    },
-    "@comunica/actor-sparql-serialize-sparql-xml": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.22.0.tgz",
-      "integrity": "sha512-vADmIcOg2A+d4MRRjp/nm1yxpRjCB1nJKaGlXgqmEfkRYKbxrhv0/WzByF6OqdrR3W3ZMTKwzAsNdo4+mWQVRQ==",
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "@types/xml": "^1.0.2",
-        "xml": "^1.0.1"
-      }
-    },
-    "@comunica/actor-sparql-serialize-stats": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.22.1.tgz",
-      "integrity": "sha512-v8OzTGRZNlh86f8C24WA3IIf8XfHQBMWJIxQsFsGeVj3jtB2ngYM7GZtr/xvcRjHooTULygcQIE4wwkW+KMlCQ==",
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/actor-sparql-serialize-table": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.22.0.tgz",
-      "integrity": "sha512-Vh8PGLHGNBnqtzqwdLAekQuneetmrpcXIdTaC+CSpjbGLamsXTfvzkPJCi4TgdxWnEmRcjMGo8MMyho0A+cToA==",
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-terms": "^1.6.2"
-      }
-    },
-    "@comunica/actor-sparql-serialize-tree": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.22.0.tgz",
-      "integrity": "sha512-ICC1jTz++ThLXjXVIbrPJvfibu1DL9eTlPpooX3P70n8RQyG80f1SBAxdn4M42Q1+YE8poRjJx1ZgxVoQ8Rnag==",
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "sparqljson-to-tree": "^2.0.0"
+        "immutable": "^4.1.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1"
       }
     },
     "@comunica/bus-context-preprocess": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.22.0.tgz",
-      "integrity": "sha512-N4Lmu8JovfhDBOuyhG/7Gaig4v+nWFYbrhCRpj5gSnbn4J8WwqNmcbwVWWi3jCgw/SGsk3QRIQaFXyS3IigydQ==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-2.8.0.tgz",
+      "integrity": "sha512-73J9mTEQAnbOV36JPP7F72iLWkSXwM5QWF0Xxtp4RwtbK54z2wBqNjvT9+FFUBzp3qFSuXzN9zhSx4+XlxIYdQ==",
+      "requires": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
     },
     "@comunica/bus-dereference": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-2.5.1.tgz",
-      "integrity": "sha512-KQTc5ZfY6bqJSQov9QYiq2mFxuTDgnN+4mzHNcyqODrIf2UYefBV453uX+nZv9cE1hdUHP8+qJiNLjO/L1y3wA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-2.8.0.tgz",
+      "integrity": "sha512-iCB3juIib4BfhzRkH/Or728dd2ClsamwsWLKQ++rhcy9fw0asy5xSrLGolZyvT+ZwiXomLOoI7Cnr1vhy4pNCQ==",
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^2.5.1",
-        "@comunica/actor-abstract-parse": "^2.5.1",
-        "@comunica/context-entries": "^2.5.1",
-        "@comunica/core": "^2.5.1",
-        "@comunica/types": "^2.5.1",
+        "@comunica/actor-abstract-mediatyped": "^2.8.0",
+        "@comunica/actor-abstract-parse": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "readable-stream": "^4.2.0"
-      },
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.5.1.tgz",
-          "integrity": "sha512-Iz8j1XqXp/A7HJVDTtEtp7hV6nuNoIjjEUgiJUiBTM5OIx7sFbGfUd10VtHPSXB/3lHHcIo34BKNZkeurNo6BA==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1"
-          }
-        },
-        "@comunica/context-entries": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.5.1.tgz",
-          "integrity": "sha512-TnF476Nv9+DfZ+JLTQU7OSqmFREScVkpBtU71seT6He+vkJBHDm6Nq4tnKwDmAI3v9dCc5dgCRU4F2uPDjBKZA==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1",
-            "@rdfjs/types": "*",
-            "jsonld-context-parser": "^2.2.2",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "@comunica/core": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-          "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-          "requires": {
-            "@comunica/types": "^2.5.1",
-            "immutable": "^4.1.0"
-          }
-        },
-        "@comunica/types": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-          "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/yargs": "^17.0.13",
-            "asynciterator": "^3.8.0",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "immutable": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-        },
-        "readable-stream": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10"
-          }
-        },
-        "sparqlalgebrajs": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-          "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.3",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.6",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.6.1"
-          }
-        }
       }
     },
     "@comunica/bus-dereference-rdf": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.5.1.tgz",
-      "integrity": "sha512-QdATU52U4wpC2OILe0p9twbHbl9LjhyeTYblcc4FaGEjgJ/8TqiWpwIzZEnCPRdE+yOy9QNXLjna5/B7hVNHsw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.8.0.tgz",
+      "integrity": "sha512-VFRSlr8ZLAagpBmKIuqhdVGrdo0cj4wFtROMLlMggudgIQw+Epl71UgOPjuRreAcs//tsYm0tscVQ5Zvshlm0Q==",
       "requires": {
-        "@comunica/bus-dereference": "^2.5.1",
-        "@comunica/bus-rdf-parse": "^2.5.1",
-        "@comunica/core": "^2.5.1",
+        "@comunica/bus-dereference": "^2.8.0",
+        "@comunica/bus-rdf-parse": "^2.8.0",
+        "@comunica/core": "^2.8.0",
         "@rdfjs/types": "*"
-      },
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.5.1.tgz",
-          "integrity": "sha512-Iz8j1XqXp/A7HJVDTtEtp7hV6nuNoIjjEUgiJUiBTM5OIx7sFbGfUd10VtHPSXB/3lHHcIo34BKNZkeurNo6BA==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1"
-          }
-        },
-        "@comunica/bus-rdf-parse": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.5.1.tgz",
-          "integrity": "sha512-BzfvedLkh1bOSa/WeUzLc/bQlcXWKhIkG/GwIOrCFtoWJOdOlapWdPvPS5U6sEW/UW454ClRWaqIA+GM0qeyzA==",
-          "requires": {
-            "@comunica/actor-abstract-mediatyped": "^2.5.1",
-            "@comunica/actor-abstract-parse": "^2.5.1",
-            "@comunica/core": "^2.5.1",
-            "@rdfjs/types": "*"
-          }
-        },
-        "@comunica/core": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-          "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-          "requires": {
-            "@comunica/types": "^2.5.1",
-            "immutable": "^4.1.0"
-          }
-        },
-        "@comunica/types": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-          "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/yargs": "^17.0.13",
-            "asynciterator": "^3.8.0",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "immutable": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-        },
-        "sparqlalgebrajs": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-          "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.3",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.6",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.6.1"
-          }
-        }
+      }
+    },
+    "@comunica/bus-hash-bindings": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-2.8.0.tgz",
+      "integrity": "sha512-zK3yoINSkQ+aF2g+JcKq/Fh7wDtnTB58Tbr/V9E4RgXu2WgZR2gQBMXEi8IxQuAuFgresxx9Ku87W1opu/btsg==",
+      "requires": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
       }
     },
     "@comunica/bus-http": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.21.1.tgz",
-      "integrity": "sha512-M6gi128ME+7uSnLPz4Bx3jgXhIb5/O7tODVHAtw9gt0z/9AAuYfmW9jqmcZ5Uwv3CCvJSvEc/m+dooCv35dTsA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.8.0.tgz",
+      "integrity": "sha512-xwH0Ep0JertuG2Xn/+lw3CgGtphPgwWuJj3p1/Ri34ORZmusrqv51/BNU63iRyr2QG4XT275V8Sj0RiHy8/PPg==",
       "requires": {
-        "@comunica/context-entries": "^1.21.1",
-        "is-stream": "^2.0.0",
-        "web-streams-node": "^0.4.0"
+        "@comunica/core": "^2.8.0",
+        "is-stream": "^2.0.1",
+        "readable-stream-node-to-web": "^1.0.1",
+        "readable-web-to-node-stream": "^3.0.2",
+        "web-streams-ponyfill": "^1.4.2"
       }
     },
     "@comunica/bus-http-invalidate": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.22.0.tgz",
-      "integrity": "sha512-JQnEvU9s+Q/OBUdKEbI15QPyO4d7opkGi1nGah9aMpFx7o3CuIa62SuzmDokfgHXOIVaOh2e6gWDNuFjCj9cBA==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-2.8.0.tgz",
+      "integrity": "sha512-As5ZIB1yEf4LFhQgsWxQDWceNMMm6dWcbs8cjj3I0AJ5FW+oOmHAD9cn4pXdghO7rKdJ36CtNP/hA9hqhOYJFw==",
+      "requires": {
+        "@comunica/core": "^2.8.0"
+      }
     },
     "@comunica/bus-init": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.21.1.tgz",
-      "integrity": "sha512-h8Gp/iJiyY8mbqhrbfLySwTXasjxmCX6kpM9RyXWqCBJzdx8Bfq6F/nYg2N+zpEJgyrn5zLdNgbBkcDetdeAmA==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.8.0.tgz",
+      "integrity": "sha512-vJaxW7plwuQXuifLfIPWjzdx2QX7goBBD+xsQOVEcJxytkQBzcRkyZMzoY/ZYjtBBvZkdgK+ks1oHupsGeUe2Q==",
+      "requires": {
+        "@comunica/core": "^2.8.0",
+        "readable-stream": "^4.2.0"
+      }
     },
     "@comunica/bus-optimize-query-operation": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.22.0.tgz",
-      "integrity": "sha512-psRjzvqYdohXIM9AYRDawe0axJM8S1RfeRWsbi+f4z18axEDMq/FEBRkmbpCoZaQ2DR2a16RcUr0ItgchWHUJQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-2.8.0.tgz",
+      "integrity": "sha512-RBNxnvsjsJnBOOPbOmZrKX8saAq6uAlIwF32+bJTWgNVDht2SEZXMLOnTazkEZIdXQ49Ih9j9OXG7pjAwmLRsA==",
       "requires": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/bus-query-operation": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.22.0.tgz",
-      "integrity": "sha512-4qRytLHR+1ghNsct9+OArnXDPQt8/PGTwLsseI7ACZ0Q8Ao1Oq212nNshC5Vl90bueh20iksHfBFBogttzsTDA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-2.8.0.tgz",
+      "integrity": "sha512-019WntrY64Mz7DMdhvO3TD22F6Jf3Cc89gLcbg2nQFcosee01wLRW1CT/WsZbU/uIyfwGtg6wbZjUZHG9jIRdQ==",
       "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
+        "@comunica/bindings-factory": "^2.7.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/data-factory": "^2.7.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "immutable": "^3.8.2",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "asynciterator": "^3.8.0",
+        "rdf-string": "^1.6.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
-    "@comunica/bus-rdf-dereference": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.21.1.tgz",
-      "integrity": "sha512-gejQdUmWCtXzlrSIVwVBuTtijLncO88hpqZjqkNo+WKTilCT9GdXSqRw137GX6ZPsBXKf/Pztupid3oUPG+2xg==",
+    "@comunica/bus-query-parse": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-2.8.0.tgz",
+      "integrity": "sha512-mRjR8DUYkWPjYqWXLytLHYr/jlgvPEtbCezo6/b4hX3pfdB2j65kzjeSYzc60QqNG3U9PKix4Y1lH7PHteiKOA==",
       "requires": {
-        "@comunica/context-entries": "^1.21.1",
-        "@types/rdf-js": "*"
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
-    "@comunica/bus-rdf-dereference-paged": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.22.0.tgz",
-      "integrity": "sha512-UMjrL8VXP5gMcESAOqMq/yhaK6MlFRPtewcG7hpOEkCKUaR2Ss3N7caGCkBc3c2aLvCjuD3aZXiiRfR+JuzRRA==",
+    "@comunica/bus-query-result-serialize": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-2.8.0.tgz",
+      "integrity": "sha512-4vNL6gRjS2GXiTfspA7VSTkquiI6w0O0BllNRjk7EkuTeX87eizG2jIgeJ+TZxaYg5Xkysh2gexWsa090GRCSw==",
       "requires": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
+        "@comunica/actor-abstract-mediatyped": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
       }
     },
     "@comunica/bus-rdf-join": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.22.0.tgz",
-      "integrity": "sha512-kxxoOnSgMCEIhU1ToSnucT1nv6ktoPwTPr3uVt/q36873WdCnfUGgd1yAMGQfTQWQbOf9BlL2dYHmJkzPvx78A==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-2.8.0.tgz",
+      "integrity": "sha512-bGc19rDb9CylWrEepvdwZx3HtQWwsDVsbTjp3SJyWNcmTLPWKG+3Slha1v4soPSlJEPVF/VZCxnsZ9oDquBrZA==",
       "requires": {
-        "@comunica/types": "^1.22.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/bus-rdf-join-selectivity": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/metadata": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "@comunica/bus-rdf-join-entries-sort": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-2.8.0.tgz",
+      "integrity": "sha512-D16zfasaw3H0buY2RzNlO6PM6DGqHjtiXywgJkhK1a+VVNoPvLBaClSCJPr6uDR1R3g3jIRfwsjjxsyAOnTmhA==",
+      "requires": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "@comunica/bus-rdf-join-selectivity": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-2.8.0.tgz",
+      "integrity": "sha512-EIMwT8mYG/Hpw9LB5Vrt+Sx06hcWl4CklGVPWhjHKB/I7dfdLeEANdIPP8X5zDxtTAU8Mp+5mjwF8Kg46rxsDQ==",
+      "requires": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/mediatortype-accuracy": "^2.8.0",
+        "@comunica/types": "^2.8.0"
       }
     },
     "@comunica/bus-rdf-metadata": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.22.0.tgz",
-      "integrity": "sha512-d/eHq4ofHDll2c9SFQkxGFg8rwsezOQJ5vktGEaic1k57297ke4tEG4JB0MdgZCUNwLieAtEtB81qj0mqW1WaA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-2.8.0.tgz",
+      "integrity": "sha512-a9j48dIh0J40nFPlEs2rNoZwpUwvDfmC/qVYLPgzJB+WoJ9+A3qXuIIqJLk4/cBhpopjqNC1uaUoLHYz7bmzdQ==",
       "requires": {
+        "@comunica/core": "^2.8.0",
         "@rdfjs/types": "*"
       }
     },
-    "@comunica/bus-rdf-metadata-extract": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.21.1.tgz",
-      "integrity": "sha512-Q1T54qlM3Vpev6H4Y/BuMpfz+Qi6/UcDeRo/eySovtCpJ2bWi8w/+UNdeGAZhYL9InqO9qJ2PUn+TiQ/sGIojg==",
+    "@comunica/bus-rdf-metadata-accumulate": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-2.8.0.tgz",
+      "integrity": "sha512-90/KIDfgsD5hrs3tZCCOHoXsh6YxeG2WEzjbtSrCB5+/qZgI6+nYWAnqXVrgmAZxELv0ah7VJ/4cNq9WpFQ6FA==",
       "requires": {
-        "@comunica/types": "^1.21.1",
-        "@types/rdf-js": "*",
-        "graphql-ld": "^1.2.0",
-        "rdf-store-stream": "^1.2.0",
-        "sparqlalgebrajs": "^2.5.5",
-        "stream-to-string": "^1.2.0"
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "@comunica/bus-rdf-metadata-extract": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-2.8.0.tgz",
+      "integrity": "sha512-mluv6pA+mpzf036ykvXZ9TNNzK1eYg0mVKte4mHDTzQAT+XUGNcKRxO00sZQ1APO0HhQqhgK2v3DfPapmFwYgg==",
+      "requires": {
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*"
       }
     },
     "@comunica/bus-rdf-parse": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.21.1.tgz",
-      "integrity": "sha512-JQD9Cgml/W+PCSEX3WulwxiQOdULFxAFDipLk69/J9WZxOj6emufxStM8M9R+pavbLaLYRcBQWgO0KLhEn/Rnw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.8.0.tgz",
+      "integrity": "sha512-ksCDIaO9egUQjfPK/GprTZAPBn58IhEpG4f38V3BoB2XwddZsVMpiyBhRECROy+E0VfpixY/5o6j1zjOeEtOkA==",
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.21.1",
-        "@types/rdf-js": "*"
+        "@comunica/actor-abstract-mediatyped": "^2.8.0",
+        "@comunica/actor-abstract-parse": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*"
       }
     },
     "@comunica/bus-rdf-parse-html": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.22.0.tgz",
-      "integrity": "sha512-zqdLdF5qvru1vnzN4t9eXpJhi6khKm1ZWhUovBB9pfYnnyGRCQCPlFpcgJPrD8JfKd6nTvhgdLB5QcAbBb1I0A==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.8.0.tgz",
+      "integrity": "sha512-KdQa+mN91XOnmYrXIEff0uoac9krpHTrh9evDMhV/mPDWU9a6dsd+1ZyKVmMi4HMN1t3ouYdDk0+4YYTkJhO+g==",
       "requires": {
+        "@comunica/core": "^2.8.0",
         "@rdfjs/types": "*"
       }
     },
     "@comunica/bus-rdf-resolve-hypermedia": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.22.0.tgz",
-      "integrity": "sha512-stZUCKUOkt7DCwgSZdhY6tFiUEj4sbkjroJg6BfA3ATJptH7waINPn1D0ytrg0NHy1+vuU+5H1E6/Qtlczuk0g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-2.8.0.tgz",
+      "integrity": "sha512-9HXCqFH8hGsRYHwhHu5vSsytPBfaHYWrWIufI6TnqNEOgQspesx4Uj1kj3yhCz5dTDFRxqzLjJT4zWmyeAl/PA==",
       "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*"
       }
     },
     "@comunica/bus-rdf-resolve-hypermedia-links": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.22.0.tgz",
-      "integrity": "sha512-w76L61DC/7PchmONzf7wYuMlN08TWN9Vr+ulse84/4+jResEYzCji5kYJV4AiAKQ868ufwuGJuskf6FJlUjqFg==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-2.8.0.tgz",
+      "integrity": "sha512-7fNME9hAzCCSrHXdThZCb/twLLYLko+HA/ODv24yVTuYHyeuBiVC5IIq+8y10ulq6bSqdZdqzf2EfjemzUCgNA==",
+      "requires": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*"
+      }
     },
     "@comunica/bus-rdf-resolve-hypermedia-links-queue": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-1.22.0.tgz",
-      "integrity": "sha512-2l+AEDwEIGD19ogk3umDuV25h0xMpHCMliefK8aL3iUqw1LzY93aHx7A2BgidfdQKrWog6R+vkazTaL/duTX2w==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-2.8.0.tgz",
+      "integrity": "sha512-f41p4ksEF2MK6NlZBepGTpA5C5jmjx89ao40/xGXSBSASgAiyFyfChDGbrNjQSTFdJlQjs76Re5iEDNAG9+BaQ==",
+      "requires": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.8.0",
+        "@comunica/core": "^2.8.0"
+      }
     },
     "@comunica/bus-rdf-resolve-quad-pattern": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.22.0.tgz",
-      "integrity": "sha512-Re3hM8mwqbPNuS23Uh0GvMI+ryC6gWMrC+johCWhDOX+iYqLv1bUgfrC0tZE4v7reMyYp6nuCVHa/9o+F3Fweg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-2.8.0.tgz",
+      "integrity": "sha512-O+ZcrtGi0tQoaOhW51JquqFrtN3Ko5xKm3nBg6TIgWphn4+jeStf64dwUkdKpVYVNe3A/iwI+c6pggUSBKWWjA==",
       "requires": {
-        "@comunica/context-entries": "^1.22.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@comunica/bus-rdf-serialize": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.22.0.tgz",
-      "integrity": "sha512-GY07qx6IIfM2GoIa8Vm8rq+iU2d/r7T6fBX61ZJxAsNKrbhtniuaqMrdZ2CL6sYKSBxVTNeRzP2l+d55So8v2Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.8.0.tgz",
+      "integrity": "sha512-Bi473F0l66MQz8PkTDLIPErLVUn/Hku05MCVkCpGb30O/EfqolP6W19XlP1fctFVAULSXVR8eXx1tuZImle9Nw==",
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
+        "@comunica/actor-abstract-mediatyped": "^2.8.0",
+        "@comunica/core": "^2.8.0",
         "@rdfjs/types": "*"
       }
     },
     "@comunica/bus-rdf-update-hypermedia": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-1.22.2.tgz",
-      "integrity": "sha512-pvTEAKDgpCuUcR+JK/8VbuhiL1WYBMe9nyWdHZrrVhQC6hJMKB6Gmrly3qc8JKVk8iPmpYyAT4Ea29DxEIl6HQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-2.8.0.tgz",
+      "integrity": "sha512-C38CBM5jO63LNBxMFWduLcflt88t4fiMgs6AMNEuEN487znLWwVDwa7Rv9s21uClvPrXm8Zn75HNJNp4IO8oyg==",
       "requires": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2"
+        "@comunica/bus-rdf-update-quads": "^2.8.0",
+        "@comunica/core": "^2.8.0"
       }
     },
     "@comunica/bus-rdf-update-quads": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-1.22.2.tgz",
-      "integrity": "sha512-MnczplJyAwZrfPAMfORKG+U8xdTxUbdKUcbopOk82JJvN3AjiDrbBetp3eS+Q+O+wV4Ae0kzrng+Q1aJ3zpiRA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-2.8.0.tgz",
+      "integrity": "sha512-G0V5UI/T5MVORyvCSubpJUsq39+HOFj3apRIRTewJQKRqnJDiWRDxIud0i4nYebDUkK8XyLkNSXE03BNtKbNGw==",
       "requires": {
-        "@comunica/bus-http": "^1.22.1",
-        "@comunica/context-entries": "^1.22.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^2.8.0",
+        "@comunica/bus-http": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
+        "asynciterator": "^3.8.0",
         "stream-to-string": "^1.2.0"
-      },
-      "dependencies": {
-        "@comunica/bus-http": {
-          "version": "1.22.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.22.1.tgz",
-          "integrity": "sha512-CZ0NDWZH0k0FOshuRQJzYr3Z+2ZM1vqr9ZepONuaoYDwyKaxl29xPs3hNfjSy6YawjEQP+elr/WDc3TxKIpu8g==",
-          "requires": {
-            "@comunica/context-entries": "^1.22.0",
-            "@types/readable-stream": "^2.3.11",
-            "is-stream": "^2.0.0",
-            "readable-web-to-node-stream": "^3.0.2",
-            "web-streams-node": "^0.4.0"
-          }
-        }
-      }
-    },
-    "@comunica/bus-sparql-parse": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.22.0.tgz",
-      "integrity": "sha512-3xnsbh5wfiCuFPMa2RHzzIIBkwVRUEdao4iydzlp3mTJjU5huWSyL6zvteIm/lIjW0HbWCQY5QfQ1FiAyZB6lA==",
-      "requires": {
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
-      }
-    },
-    "@comunica/bus-sparql-serialize": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.22.0.tgz",
-      "integrity": "sha512-qBlhEkEwtScGLrlebu2YqWbyAR/765zNtxqQqUBfEXaf+3ahmSACpwKFMuxJh0v7VXWCQNKYTA5WfFlEz7V4Uw==",
-      "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@comunica/types": "^1.22.0"
       }
     },
     "@comunica/config-query-sparql": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-2.5.1.tgz",
-      "integrity": "sha512-Fg/PDp0BwoFcCBeVTPTDR8pgXjuuMXTLi3SJFT0GdgtwSPHlAikMHGywyOMK9I1TlZ2Fwwl/oIhZVNFY3Uz7YA=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-2.7.0.tgz",
+      "integrity": "sha512-rMnFgT7cz9+0z7wV4OzIMY5qM9/Z0mTGrR8y2JokoHyyTcBGOSajFmy61XCSLMCsLLG8qDXsJ4ClCCky3TGfqA=="
     },
     "@comunica/context-entries": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-1.22.0.tgz",
-      "integrity": "sha512-HOYr1HdhgavxABpw8saZa9pueLAeGVVd/6cZ3FWcYnH3CvfQu6Ima06Gd00QdIAiGjQm01qQcWCxp0xURiqLKg=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.8.0.tgz",
+      "integrity": "sha512-dwTyRatuHoEkPuNGzjfB68ctKWeYD7z6RaphtraWPoE/bkU5LGWlFBa5l/H6c/thjBVsc6Ds2iBxziR6A699iA==",
+      "requires": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.2.2",
+        "sparqlalgebrajs": "^4.2.0"
+      }
     },
     "@comunica/core": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.21.1.tgz",
-      "integrity": "sha512-5lY/HkyOCorY2CtxQiKUKEOcUGjIKf/YG/txJrz84SKuy+zC91zq1Zt8qWfzNihCcWrgfmk0oZuvjbYvZGK4EA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-x9U223laJ/WnPWpOyOuZ1zBygtl1UKmlySspzT+8SZrByervWIe836Xkt1JP0JNTMh54FlRa6Pg1DwYcoin5Hg==",
       "requires": {
-        "@comunica/context-entries": "^1.21.1",
-        "@comunica/types": "^1.21.1",
-        "immutable": "^3.8.2"
+        "@comunica/types": "^2.8.0",
+        "immutable": "^4.1.0"
       }
     },
     "@comunica/data-factory": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-1.22.0.tgz",
-      "integrity": "sha512-t18NJMdB6n/CjhNKIfofTkAL2YClj842se8utnk2sfCis9OIdUW8EuRfR9iyFHmVFdfe2RjEeKBPd6iye5Ns3Q==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-2.7.0.tgz",
+      "integrity": "sha512-dSTzrR1w9SzAWx70ZXKXHUC8f0leUolLZ9TOhGjFhhsBMJ9Pbo0g6vHV8txX5FViShngrg9QNKhsHeQnMk5z6Q==",
       "requires": {
         "@rdfjs/types": "*"
       }
     },
     "@comunica/logger-pretty": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.22.0.tgz",
-      "integrity": "sha512-YCCRDIvbhWAygEqADnKnbCt7jnR4AasnoukLOQKyv1JAYxEV61FqReGG2LMtCqYR4VWUAa9tr51Ov+vOH1cMBg==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-2.8.0.tgz",
+      "integrity": "sha512-rehoKAoH0weUEisdR4F2wyPK7DNHDKWRCa8b+UafRJRfXV10VcBSQCz6ba3wuP9u1eQujVMbBmV3lCmVAPIOGg==",
+      "requires": {
+        "@comunica/types": "^2.8.0",
+        "object-inspect": "^1.12.2",
+        "process": "^0.11.10"
+      }
     },
     "@comunica/logger-void": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.22.0.tgz",
-      "integrity": "sha512-ORLVmoE47wqWZGdNKcZ8wpnEHtfcUKGhnDt5KbS/YV2qv4m/dG9eNIn6ax5FZeX2EFDSzWtlvMYNxNFhTvb7VQ==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-2.8.0.tgz",
+      "integrity": "sha512-l13W2cX3u+fRJ31v5ik7xurQFbP7yqTknmqAdArf9cpJ5o+AbeEZv/wBud6Ws6dq8hmcgEDtN4cECR6MmQvSAQ==",
+      "requires": {
+        "@comunica/types": "^2.8.0"
+      }
     },
     "@comunica/mediator-all": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.22.0.tgz",
-      "integrity": "sha512-jr+tYDDDJuVeW20yauB6GH3Xov0I9eW1y0V69hgcFgyi2xTBN1z+X7OkLjOBVFzYJnHmpr+rLvpxkZIiYcOW/w==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-2.8.0.tgz",
+      "integrity": "sha512-kbbIKRel+l3WjIRMxQXnQwWMIdhLpb4qskKzC4INtsDyCAIBOsX3YR9dQJzvvuHq/W30ICYBen+7SLiYFR2LPg==",
+      "requires": {
+        "@comunica/core": "^2.8.0"
+      }
     },
     "@comunica/mediator-combine-pipeline": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.22.0.tgz",
-      "integrity": "sha512-SSXOvup8vlw1tS60RICXO3N+pK+7OzpwFmw5VuIVfliIdzAklEBoMUy4BucxlyX64Pgvt6nUXvaSvY3JGf9GXw==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.8.0.tgz",
+      "integrity": "sha512-onXpWpTmtHPEWdXiZezelnt2sbGHrUHGnw+N8H15QlfC45nrHz6NhH7FEdc+L9q2VjgtXdlfR84x/senNAMCfw==",
+      "requires": {
+        "@comunica/core": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
     },
     "@comunica/mediator-combine-union": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.21.1.tgz",
-      "integrity": "sha512-wp2lbViVOOeNKTBRD+6sze7TKVX71T2RD324/1Syb8vOpwT3mtaDNJYFg0Mrwer/Xs54d7nA7JGZA2wC2HaXow==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.8.0.tgz",
+      "integrity": "sha512-2ZqItxIX4lb1VYBo6TFm1SfDXZ0iqZ2c3r/WlukEx3sC2/C3cTG53jvjaxb6B/0fi86fGykv7wrQKinbaE+GWQ==",
+      "requires": {
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/mediator-join-coefficients-fixed": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-2.8.0.tgz",
+      "integrity": "sha512-Qmee8MbiQP1C1KyRJ0BuyMorH3t0DbLM7l7ccSRCTdnmRgDYn7yljJZ5QAgblgdm6gZXhYsCNXpLydGJjImtAw==",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.8.0",
+        "@comunica/context-entries": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/mediatortype-join-coefficients": "^2.8.0",
+        "@comunica/types": "^2.8.0"
+      }
     },
     "@comunica/mediator-number": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.21.1.tgz",
-      "integrity": "sha512-OeuGx0R/mWI1uMMXM2V1vcR8J1DPhYXPR+Ncg4/qKHl7tSCQH1tlCgZu0+fovY2Qmc14f1tmw5YgnsE8lsikSQ==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.8.0.tgz",
+      "integrity": "sha512-IrdFeV2FHTwUUXfWjdP+OE9mBfqZwBm/T6jF02Vlr+NWqMFGmMoMu0W+PnAg6YznqnqonLInF4HRj8QIsidHGA==",
+      "requires": {
+        "@comunica/core": "^2.8.0"
+      }
     },
     "@comunica/mediator-race": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.21.1.tgz",
-      "integrity": "sha512-SgdtF1JmqDyhZJsAOiVMPuV1qgdXqv/hbsFCxcmDQ+8q1ObmQ+0DZvdUe5Ymf2IyFaevsOHHG7hF5hJbLZmdmQ==",
-      "requires": {}
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.8.0.tgz",
+      "integrity": "sha512-cI7BCKKeo+1LgaMzBRw1s9ZINSB/N6zULEznCxQs02Im0U4NUHs0sc6KTdACI8m4iNEM960EjDOFr7CeA8275g==",
+      "requires": {
+        "@comunica/core": "^2.8.0"
+      }
     },
-    "@comunica/mediatortype-iterations": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-iterations/-/mediatortype-iterations-1.22.0.tgz",
-      "integrity": "sha512-pN8aCGSh19FFu2IHjXJdCib2ewhOuW+DzQVkGTG0oD472amqQAlBVNxR38QParVP/ra70Isnbp+mfFlFLHrkYg==",
-      "requires": {}
+    "@comunica/mediatortype-accuracy": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-2.8.0.tgz",
+      "integrity": "sha512-5WmCCpGHdwkygwxs2hLrGqQIQkeCoTHHs+bzVVgFPudvryJzatLQACBVrojAs3pk7rS+3I31BxCwmaU7QcRRsQ==",
+      "requires": {
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/mediatortype-httprequests": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-httprequests/-/mediatortype-httprequests-2.8.0.tgz",
+      "integrity": "sha512-128F3cSndJWkLktiir95uLKiFnt7QgYZ7k5slvtrRms1pbjQb5zAP7dUwoMFEGfyVis0kvYiIPn500rXeGa36w==",
+      "requires": {
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/mediatortype-join-coefficients": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-2.8.0.tgz",
+      "integrity": "sha512-5axVSMduA4ao9OiuIJi6nejEohdBOLAAJVMcOuypojhTJA5GAhQh1HEbnjLIGaUwXWQMuB7CCgHWn6hNDMo5Hw==",
+      "requires": {
+        "@comunica/core": "^2.8.0",
+        "@rdfjs/types": "*"
+      }
     },
     "@comunica/mediatortype-time": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.5.1.tgz",
-      "integrity": "sha512-3xaRx+MzUtKd8LXJcMOB2VwuH9FrgODStUaVbkcAwBoPLxFJzYvgtv49iF/e8X3vY1u0EYzJMQXjuA3sV5niRw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.8.0.tgz",
+      "integrity": "sha512-NCfn2AtX1z2rxRTQyyPkvOs1IEFUClNPOE7NaS4wg67jcWYQRKITcxf9CUT/UkMqG25MkkepMo75DiqqFmmarg==",
       "requires": {
-        "@comunica/core": "^2.5.1"
-      },
-      "dependencies": {
-        "@comunica/core": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-          "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-          "requires": {
-            "@comunica/types": "^2.5.1",
-            "immutable": "^4.1.0"
-          }
-        },
-        "@comunica/types": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-          "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/yargs": "^17.0.13",
-            "asynciterator": "^3.8.0",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "immutable": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-        },
-        "sparqlalgebrajs": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-          "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.3",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.6",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.6.1"
-          }
-        }
+        "@comunica/core": "^2.8.0"
+      }
+    },
+    "@comunica/metadata": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/metadata/-/metadata-2.8.0.tgz",
+      "integrity": "sha512-sd0SZsmv5QBg5yon8lAXhIx1KBLfVNg0qPWR3bOSbrQqKAW0YUAGJ4o8ut2WnmquWTZIHAmDQLKwluT8pvot/g==",
+      "requires": {
+        "@comunica/types": "^2.8.0"
+      }
+    },
+    "@comunica/query-sparql": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/query-sparql/-/query-sparql-2.8.0.tgz",
+      "integrity": "sha512-ynFsbxgBQzlfALd87bUdCUOTZQK4oiMS852AHHMfHdIV4ya8nTmvEot4oXpjO46dggIbTZsUiSDA68MG7RajPQ==",
+      "requires": {
+        "@comunica/actor-context-preprocess-source-to-destination": "^2.8.0",
+        "@comunica/actor-dereference-fallback": "^2.8.0",
+        "@comunica/actor-dereference-http": "^2.8.0",
+        "@comunica/actor-dereference-rdf-parse": "^2.8.0",
+        "@comunica/actor-hash-bindings-sha1": "^2.8.0",
+        "@comunica/actor-http-fetch": "^2.8.0",
+        "@comunica/actor-http-proxy": "^2.8.0",
+        "@comunica/actor-http-wayback": "^2.8.0",
+        "@comunica/actor-init-query": "^2.8.0",
+        "@comunica/actor-optimize-query-operation-bgp-to-join": "^2.8.0",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^2.8.0",
+        "@comunica/actor-optimize-query-operation-join-connected": "^2.8.0",
+        "@comunica/actor-query-operation-ask": "^2.8.0",
+        "@comunica/actor-query-operation-bgp-join": "^2.8.0",
+        "@comunica/actor-query-operation-construct": "^2.8.0",
+        "@comunica/actor-query-operation-describe-subject": "^2.8.0",
+        "@comunica/actor-query-operation-distinct-hash": "^2.8.0",
+        "@comunica/actor-query-operation-extend": "^2.8.0",
+        "@comunica/actor-query-operation-filter-sparqlee": "^2.8.0",
+        "@comunica/actor-query-operation-from-quad": "^2.8.0",
+        "@comunica/actor-query-operation-group": "^2.8.0",
+        "@comunica/actor-query-operation-join": "^2.8.0",
+        "@comunica/actor-query-operation-leftjoin": "^2.8.0",
+        "@comunica/actor-query-operation-minus": "^2.8.0",
+        "@comunica/actor-query-operation-nop": "^2.8.0",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^2.8.0",
+        "@comunica/actor-query-operation-path-alt": "^2.8.0",
+        "@comunica/actor-query-operation-path-inv": "^2.8.0",
+        "@comunica/actor-query-operation-path-link": "^2.8.0",
+        "@comunica/actor-query-operation-path-nps": "^2.8.0",
+        "@comunica/actor-query-operation-path-one-or-more": "^2.8.0",
+        "@comunica/actor-query-operation-path-seq": "^2.8.0",
+        "@comunica/actor-query-operation-path-zero-or-more": "^2.8.0",
+        "@comunica/actor-query-operation-path-zero-or-one": "^2.8.0",
+        "@comunica/actor-query-operation-project": "^2.8.0",
+        "@comunica/actor-query-operation-quadpattern": "^2.8.0",
+        "@comunica/actor-query-operation-reduced-hash": "^2.8.0",
+        "@comunica/actor-query-operation-service": "^2.8.0",
+        "@comunica/actor-query-operation-slice": "^2.8.0",
+        "@comunica/actor-query-operation-sparql-endpoint": "^2.8.0",
+        "@comunica/actor-query-operation-union": "^2.8.0",
+        "@comunica/actor-query-operation-update-add-rewrite": "^2.8.0",
+        "@comunica/actor-query-operation-update-clear": "^2.8.0",
+        "@comunica/actor-query-operation-update-compositeupdate": "^2.8.0",
+        "@comunica/actor-query-operation-update-copy-rewrite": "^2.8.0",
+        "@comunica/actor-query-operation-update-create": "^2.8.0",
+        "@comunica/actor-query-operation-update-deleteinsert": "^2.8.0",
+        "@comunica/actor-query-operation-update-drop": "^2.8.0",
+        "@comunica/actor-query-operation-update-load": "^2.8.0",
+        "@comunica/actor-query-operation-update-move-rewrite": "^2.8.0",
+        "@comunica/actor-query-operation-values": "^2.8.0",
+        "@comunica/actor-query-parse-graphql": "^2.8.0",
+        "@comunica/actor-query-parse-sparql": "^2.8.0",
+        "@comunica/actor-query-result-serialize-json": "^2.8.0",
+        "@comunica/actor-query-result-serialize-rdf": "^2.8.0",
+        "@comunica/actor-query-result-serialize-simple": "^2.8.0",
+        "@comunica/actor-query-result-serialize-sparql-csv": "^2.8.0",
+        "@comunica/actor-query-result-serialize-sparql-json": "^2.8.0",
+        "@comunica/actor-query-result-serialize-sparql-tsv": "^2.8.0",
+        "@comunica/actor-query-result-serialize-sparql-xml": "^2.8.0",
+        "@comunica/actor-query-result-serialize-stats": "^2.8.0",
+        "@comunica/actor-query-result-serialize-table": "^2.8.0",
+        "@comunica/actor-query-result-serialize-tree": "^2.8.0",
+        "@comunica/actor-rdf-join-entries-sort-cardinality": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-hash": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-multi-bind": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-multi-empty": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-multi-smallest": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-nestedloop": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-none": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-single": "^2.8.0",
+        "@comunica/actor-rdf-join-inner-symmetrichash": "^2.8.0",
+        "@comunica/actor-rdf-join-minus-hash": "^2.8.0",
+        "@comunica/actor-rdf-join-minus-hash-undef": "^2.8.0",
+        "@comunica/actor-rdf-join-optional-bind": "^2.8.0",
+        "@comunica/actor-rdf-join-optional-nestedloop": "^2.8.0",
+        "@comunica/actor-rdf-join-selectivity-variable-counting": "^2.8.0",
+        "@comunica/actor-rdf-metadata-accumulate-cancontainundefs": "^2.8.0",
+        "@comunica/actor-rdf-metadata-accumulate-cardinality": "^2.8.0",
+        "@comunica/actor-rdf-metadata-accumulate-pagesize": "^2.8.0",
+        "@comunica/actor-rdf-metadata-accumulate-requesttime": "^2.8.0",
+        "@comunica/actor-rdf-metadata-all": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-allow-http-methods": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-pagesize": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-put-accepted": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-request-time": "^2.8.0",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^2.8.0",
+        "@comunica/actor-rdf-metadata-primary-topic": "^2.8.0",
+        "@comunica/actor-rdf-parse-html": "^2.8.0",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.8.0",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.8.0",
+        "@comunica/actor-rdf-parse-html-script": "^2.8.0",
+        "@comunica/actor-rdf-parse-jsonld": "^2.8.0",
+        "@comunica/actor-rdf-parse-n3": "^2.8.0",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.8.0",
+        "@comunica/actor-rdf-parse-shaclc": "^2.8.0",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.8.0",
+        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^2.8.0",
+        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^2.8.0",
+        "@comunica/actor-rdf-resolve-hypermedia-none": "^2.8.0",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^2.8.0",
+        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^2.8.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^2.8.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^2.8.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.8.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-string-source": "^2.8.0",
+        "@comunica/actor-rdf-serialize-jsonld": "^2.8.0",
+        "@comunica/actor-rdf-serialize-n3": "^2.8.0",
+        "@comunica/actor-rdf-serialize-shaclc": "^2.8.0",
+        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^2.8.0",
+        "@comunica/actor-rdf-update-hypermedia-put-ldp": "^2.8.0",
+        "@comunica/actor-rdf-update-hypermedia-sparql": "^2.8.0",
+        "@comunica/actor-rdf-update-quads-hypermedia": "^2.8.0",
+        "@comunica/actor-rdf-update-quads-rdfjs-store": "^2.8.0",
+        "@comunica/bus-http-invalidate": "^2.8.0",
+        "@comunica/bus-query-operation": "^2.8.0",
+        "@comunica/config-query-sparql": "^2.7.0",
+        "@comunica/core": "^2.8.0",
+        "@comunica/logger-void": "^2.8.0",
+        "@comunica/mediator-all": "^2.8.0",
+        "@comunica/mediator-combine-pipeline": "^2.8.0",
+        "@comunica/mediator-combine-union": "^2.8.0",
+        "@comunica/mediator-join-coefficients-fixed": "^2.8.0",
+        "@comunica/mediator-number": "^2.8.0",
+        "@comunica/mediator-race": "^2.8.0",
+        "@comunica/runner": "^2.8.0",
+        "@comunica/runner-cli": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "process": "^0.11.10"
       }
     },
     "@comunica/runner": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.21.1.tgz",
-      "integrity": "sha512-yFeHvFLGHTYXlROK6xKoWLnW0Wx0jL+NRzvB3izIXc+p34bOuua8sjmGFQzW0OU7/04S0xM8BUTG2n33s26yUw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-2.8.0.tgz",
+      "integrity": "sha512-d6Tu53/hQWTzREidxLq36JF6xbJmFzIO8k+qMtVSqLfAbGAUNxcitZU2gjpboB0ZHf6eOSDbaAxz6o8aQgdgWQ==",
       "requires": {
-        "componentsjs": "^4.0.6"
+        "@comunica/bus-init": "^2.8.0",
+        "@comunica/core": "^2.8.0",
+        "componentsjs": "^5.3.2",
+        "process": "^0.11.10"
       }
     },
     "@comunica/runner-cli": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.21.1.tgz",
-      "integrity": "sha512-T25yhU+2WJrP0xcYYpKiCPFSedy5Ml8/3geuPgU/FZZijma2jb9+PA1R9n9Mayr+Eqj37G6blcjgZ2cIVpo4aA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-2.8.0.tgz",
+      "integrity": "sha512-//cHQNbqL/WtvZf/foc5Oc7JQnd7uiiamfsSRmDg7xwVJpUsz3Lgc/ONej15oAjY9lw9OWDJUKpQahdrMGeN9A==",
       "requires": {
-        "@comunica/runner": "^1.21.1"
+        "@comunica/core": "^2.8.0",
+        "@comunica/runner": "^2.8.0",
+        "@comunica/types": "^2.8.0",
+        "process": "^0.11.10"
       }
     },
     "@comunica/types": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-1.22.0.tgz",
-      "integrity": "sha512-ZQ8p+ZvMAKmdq6Hz2QwqIQ2JScwRMotiWz0iSw2zYHsYQOhVmLg7HSMzMHpWNEA5UWzO/A5A+Co/ONXMhlnx3g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.8.0.tgz",
+      "integrity": "sha512-LxVN0Qzl74uMgLqztKDDIkDngpETx++edg/PIhBdbzHjmiyZfPhfpClm+QebiBAFVZCC1kLioNklm67Ih8Io6Q==",
       "requires": {
         "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "immutable": "^3.8.2",
-        "sparqlalgebrajs": "^3.0.1"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
-      }
-    },
-    "@comunica/utils-datasource": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.22.2.tgz",
-      "integrity": "sha512-f4md6ydlNu/0lCrcts0T+Rqwbyx68IdmCvyd8DChg/hWlVqKbrKW8RKPzYhIN7kyF/+IDqg0a0KVpoaaD1mBYw==",
-      "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/context-entries": "^1.22.0",
-        "asynciterator": "^3.2.0"
+        "@types/yargs": "^17.0.13",
+        "asynciterator": "^3.8.0",
+        "sparqlalgebrajs": "^4.2.0"
       }
     },
     "@cspotcode/source-map-support": {
@@ -15673,6 +14201,18 @@
       "peer": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "peer": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
       }
     },
     "@dabh/diagnostics": {
@@ -15702,424 +14242,6 @@
         "stream-to-string": "^1.2.0",
         "streamify-array": "^1.0.1",
         "web-streams-node": "^0.4.0"
-      },
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.5.1.tgz",
-          "integrity": "sha512-Iz8j1XqXp/A7HJVDTtEtp7hV6nuNoIjjEUgiJUiBTM5OIx7sFbGfUd10VtHPSXB/3lHHcIo34BKNZkeurNo6BA==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1"
-          }
-        },
-        "@comunica/actor-http-proxy": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.5.1.tgz",
-          "integrity": "sha512-VlBxLWgg0wC+xl3Ut8ZNSADHJZR472+VB8YI+MkQhU2uUvvt5eHUzaEu0QDY7K9sjEfbw+qh6plXCum1REOYhg==",
-          "requires": {
-            "@comunica/bus-http": "^2.5.1",
-            "@comunica/context-entries": "^2.5.1",
-            "@comunica/mediatortype-time": "^2.5.1",
-            "@comunica/types": "^2.5.1"
-          }
-        },
-        "@comunica/actor-rdf-parse-html": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.5.1.tgz",
-          "integrity": "sha512-2cbJ4YfII1Rvh7787/fA3OLn5+8mwp3qwiXQtxZEkuqRhsG635oUb4mQrKwywi3y2UzbK4i2fO2248qLK7HSgg==",
-          "requires": {
-            "@comunica/bus-rdf-parse": "^2.5.1",
-            "@comunica/bus-rdf-parse-html": "^2.5.1",
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1",
-            "@rdfjs/types": "*",
-            "htmlparser2": "^8.0.1",
-            "readable-stream": "^4.2.0"
-          }
-        },
-        "@comunica/actor-rdf-parse-html-microdata": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.5.1.tgz",
-          "integrity": "sha512-hXpIwvBOjBLLM4ppEcu1wofjNRFavP33OHpK/Z5toOE1oyrLLtwJFpFxgc1zobhJibYuTskLlhkaCo4w5wVASA==",
-          "requires": {
-            "@comunica/bus-rdf-parse-html": "^2.5.1",
-            "@comunica/core": "^2.5.1",
-            "microdata-rdf-streaming-parser": "^2.0.1"
-          }
-        },
-        "@comunica/actor-rdf-parse-html-rdfa": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.5.1.tgz",
-          "integrity": "sha512-hGQ2cZC3glZVdyk4CbmLS5aDTCVHirDYqZ35484MsEipitp+bOJ9/Zg/oXRjs7DtqKmtgqUgw8FGn7dUgnzHPg==",
-          "requires": {
-            "@comunica/bus-rdf-parse-html": "^2.5.1",
-            "@comunica/core": "^2.5.1",
-            "rdfa-streaming-parser": "^2.0.1"
-          }
-        },
-        "@comunica/actor-rdf-parse-html-script": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.5.1.tgz",
-          "integrity": "sha512-GArg4XS6CHJbnkABYzVmyiWqNhmRHJdCUWWFMJeqYOPK5Smt5FRDdpDl0Pkh4mcUt0RBRTd0l9zW6AcuLK7iug==",
-          "requires": {
-            "@comunica/bus-rdf-parse": "^2.5.1",
-            "@comunica/bus-rdf-parse-html": "^2.5.1",
-            "@comunica/context-entries": "^2.5.1",
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1",
-            "@rdfjs/types": "*",
-            "readable-stream": "^4.2.0",
-            "relative-to-absolute-iri": "^1.0.7"
-          }
-        },
-        "@comunica/actor-rdf-parse-jsonld": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.5.1.tgz",
-          "integrity": "sha512-zJxVAxDQY6CCJCrWHO+07f0PK2DwlSU00hJO2n5Y+7lkicmcUcgSbVxE3CEI0/8aq/8p2jUcCEs++hgIpeArlg==",
-          "requires": {
-            "@comunica/bus-http": "^2.5.1",
-            "@comunica/bus-rdf-parse": "^2.5.1",
-            "@comunica/context-entries": "^2.5.1",
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1",
-            "jsonld-context-parser": "^2.2.2",
-            "jsonld-streaming-parser": "^3.0.1",
-            "stream-to-string": "^1.2.0"
-          }
-        },
-        "@comunica/actor-rdf-parse-n3": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.5.1.tgz",
-          "integrity": "sha512-N6P7r2co80RFrjurldR+DCz7ajqj7Ck2QLuZhCaZZY2n6IBsfdt9QcYcuMlhykYjt+/u6tVQEuWj/XWQy6mpYQ==",
-          "requires": {
-            "@comunica/bus-rdf-parse": "^2.5.1",
-            "@comunica/types": "^2.5.1",
-            "n3": "^1.16.3"
-          }
-        },
-        "@comunica/actor-rdf-parse-rdfxml": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.5.1.tgz",
-          "integrity": "sha512-MKRSh3GIHXCOMHskcZPdggY7O5GkBfLNoNt4HYe+08jR9/Kib8rEfd4ErKi9mbuWJbXciA84HLt3ebZpmydaKA==",
-          "requires": {
-            "@comunica/bus-rdf-parse": "^2.5.1",
-            "@comunica/types": "^2.5.1",
-            "rdfxml-streaming-parser": "^2.2.1"
-          }
-        },
-        "@comunica/actor-rdf-parse-xml-rdfa": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.5.1.tgz",
-          "integrity": "sha512-NbNaGcUepRz908nAVytKmTFn0dXOLdG88oD8ldI6Aw0HDvQU6Iw5r5eSaunfZONYYFT30eTZrGUyg3efwwfuvw==",
-          "requires": {
-            "@comunica/bus-rdf-parse": "^2.5.1",
-            "@comunica/types": "^2.5.1",
-            "rdfa-streaming-parser": "^2.0.1"
-          }
-        },
-        "@comunica/bus-http": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.5.1.tgz",
-          "integrity": "sha512-kouDqVoP6qAVQ4pflMmedBHfMtuLoBgqwX3mHdlUtrE0h1I+/EX6M5eUe5pXI6PfJrn3cInHyu+UZkbZYrykAw==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "is-stream": "^2.0.1",
-            "readable-stream-node-to-web": "^1.0.1",
-            "readable-web-to-node-stream": "^3.0.2",
-            "web-streams-ponyfill": "^1.4.2"
-          }
-        },
-        "@comunica/bus-init": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.5.1.tgz",
-          "integrity": "sha512-TDakSkGzM+3xkZ+xBCBmzWNagmDWUc+F6TPYOFO8goaT1+tVrPh9wPD5t2n1zkKMzG2dOVT4O8jxUfCyzmNwKA==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "readable-stream": "^4.2.0"
-          }
-        },
-        "@comunica/bus-rdf-parse": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.5.1.tgz",
-          "integrity": "sha512-BzfvedLkh1bOSa/WeUzLc/bQlcXWKhIkG/GwIOrCFtoWJOdOlapWdPvPS5U6sEW/UW454ClRWaqIA+GM0qeyzA==",
-          "requires": {
-            "@comunica/actor-abstract-mediatyped": "^2.5.1",
-            "@comunica/actor-abstract-parse": "^2.5.1",
-            "@comunica/core": "^2.5.1",
-            "@rdfjs/types": "*"
-          }
-        },
-        "@comunica/bus-rdf-parse-html": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.5.1.tgz",
-          "integrity": "sha512-+YZiAbA2h82/+FGDJPjqHdfq6l0dm3W11V0jHcOaAsk+AK2JvvoouYdFAGshhroxQwv5WPsXbtzy6XJmVtZ4MQ==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "@rdfjs/types": "*"
-          }
-        },
-        "@comunica/context-entries": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.5.1.tgz",
-          "integrity": "sha512-TnF476Nv9+DfZ+JLTQU7OSqmFREScVkpBtU71seT6He+vkJBHDm6Nq4tnKwDmAI3v9dCc5dgCRU4F2uPDjBKZA==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1",
-            "@rdfjs/types": "*",
-            "jsonld-context-parser": "^2.2.2",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "@comunica/core": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-          "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-          "requires": {
-            "@comunica/types": "^2.5.1",
-            "immutable": "^4.1.0"
-          }
-        },
-        "@comunica/mediator-combine-pipeline": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.5.1.tgz",
-          "integrity": "sha512-vsi6YA7NGPQoNSPtKHWUbsDK+678w0BdE9DEzLWOa2pqiWoeT4SuJV4szHQNVuJjzi6j6VTXuR58mZL7XqreTw==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1"
-          }
-        },
-        "@comunica/mediator-combine-union": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.5.1.tgz",
-          "integrity": "sha512-vpbQn3xtoX+F00xv+AKbn+qUe66rIiycbiZoE/s/qtlmUbVKLItEMMuToDGRdcdC9mtPiieIrgremXd/RVdHTw==",
-          "requires": {
-            "@comunica/core": "^2.5.1"
-          }
-        },
-        "@comunica/mediator-number": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.5.1.tgz",
-          "integrity": "sha512-pOTtj5WJEh8gNlNesxe7YG90J2dQobp8ulkzP/bzsd/DC14OOxYlcTke/c+GqZH6SaatUmz/R7Za5AWdipqYcw==",
-          "requires": {
-            "@comunica/core": "^2.5.1"
-          }
-        },
-        "@comunica/mediator-race": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.5.1.tgz",
-          "integrity": "sha512-VuHHZSDagK9k85NBTEvbbhkb/Xd9zgt9jBlYIVRarushJ8ihqfs8dXQ2Hs0gdOTyrCMFiQIimbN1h58QcmmKyg==",
-          "requires": {
-            "@comunica/core": "^2.5.1"
-          }
-        },
-        "@comunica/types": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-          "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/yargs": "^17.0.13",
-            "asynciterator": "^3.8.0",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "dom-serializer": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-          "requires": {
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.2",
-            "entities": "^4.2.0"
-          }
-        },
-        "domhandler": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-          "requires": {
-            "domelementtype": "^2.3.0"
-          }
-        },
-        "domutils": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-          "requires": {
-            "dom-serializer": "^2.0.0",
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.1"
-          }
-        },
-        "entities": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
-        },
-        "htmlparser2": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-          "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
-          "requires": {
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.2",
-            "domutils": "^3.0.1",
-            "entities": "^4.3.0"
-          }
-        },
-        "immutable": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-        },
-        "jsonld-streaming-parser": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.0.1.tgz",
-          "integrity": "sha512-zSJlEgrKypQDk/85R+xkudeCZo6vmnvJuCPvcjk2BzHPLzv1yqiwoKQDyFzfgfgCHM0p7YCJBZl0liT9RMUZJw==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/http-link-header": "^1.0.1",
-            "@types/readable-stream": "^2.3.13",
-            "buffer": "^6.0.3",
-            "canonicalize": "^1.0.1",
-            "http-link-header": "^1.0.2",
-            "jsonld-context-parser": "^2.1.3",
-            "jsonparse": "^1.3.1",
-            "rdf-data-factory": "^1.1.0",
-            "readable-stream": "^4.0.0"
-          }
-        },
-        "microdata-rdf-streaming-parser": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-2.0.1.tgz",
-          "integrity": "sha512-oEEYP3OwPGOtoE4eIyJvX1eJXI7VkGR4gKYqpEufaRXc2ele/Tkid/KMU3Los13wGrOq6woSxLEGOYSHzpRvwA==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "htmlparser2": "^8.0.0",
-            "rdf-data-factory": "^1.1.0",
-            "readable-stream": "^4.1.0",
-            "relative-to-absolute-iri": "^1.0.2"
-          }
-        },
-        "rdf-dereference": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/rdf-dereference/-/rdf-dereference-2.0.1.tgz",
-          "integrity": "sha512-iiVAljvo4a/k48/TvqdHOTPmL83IBjYyRWizZQQZa50nGCvbbIvdh24LpvZQVF1g3fOB+SpGUktJAqQoUTt7Rw==",
-          "requires": {
-            "@comunica/actor-dereference-fallback": "^2.0.2",
-            "@comunica/actor-dereference-file": "^2.0.2",
-            "@comunica/actor-dereference-http": "^2.0.2",
-            "@comunica/actor-dereference-rdf-parse": "^2.0.2",
-            "@comunica/actor-http-fetch": "^2.0.1",
-            "@comunica/actor-http-proxy": "^2.0.1",
-            "@comunica/actor-rdf-parse-html": "^2.0.1",
-            "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
-            "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
-            "@comunica/actor-rdf-parse-html-script": "^2.0.1",
-            "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
-            "@comunica/actor-rdf-parse-n3": "^2.0.1",
-            "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
-            "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
-            "@comunica/bus-dereference": "^2.0.2",
-            "@comunica/bus-dereference-rdf": "^2.0.2",
-            "@comunica/bus-http": "^2.0.1",
-            "@comunica/bus-init": "^2.0.1",
-            "@comunica/bus-rdf-parse": "^2.0.1",
-            "@comunica/bus-rdf-parse-html": "^2.0.1",
-            "@comunica/config-query-sparql": "^2.0.1",
-            "@comunica/core": "^2.0.1",
-            "@comunica/mediator-combine-pipeline": "^2.0.1",
-            "@comunica/mediator-combine-union": "^2.0.1",
-            "@comunica/mediator-number": "^2.0.1",
-            "@comunica/mediator-race": "^2.0.1",
-            "@rdfjs/types": "*",
-            "rdf-string": "^1.6.0",
-            "stream-to-string": "^1.2.0"
-          }
-        },
-        "rdf-parse": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.1.1.tgz",
-          "integrity": "sha512-JOTB7381bAdvab9ZM8IZq6Egj9tuTt7XSGlrQzDCFrlAjvc7z4cMxKawgk1kZaoS/CevNSrHYsyEaBwgNyl1KA==",
-          "requires": {
-            "@comunica/actor-http-fetch": "^2.0.1",
-            "@comunica/actor-http-proxy": "^2.0.1",
-            "@comunica/actor-rdf-parse-html": "^2.0.1",
-            "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
-            "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
-            "@comunica/actor-rdf-parse-html-script": "^2.0.1",
-            "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
-            "@comunica/actor-rdf-parse-n3": "^2.0.1",
-            "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
-            "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
-            "@comunica/bus-http": "^2.0.1",
-            "@comunica/bus-init": "^2.0.1",
-            "@comunica/bus-rdf-parse": "^2.0.1",
-            "@comunica/bus-rdf-parse-html": "^2.0.1",
-            "@comunica/config-query-sparql": "^2.0.1",
-            "@comunica/core": "^2.0.1",
-            "@comunica/mediator-combine-pipeline": "^2.0.1",
-            "@comunica/mediator-combine-union": "^2.0.1",
-            "@comunica/mediator-number": "^2.0.1",
-            "@comunica/mediator-race": "^2.0.1",
-            "@rdfjs/types": "*",
-            "stream-to-string": "^1.2.0"
-          }
-        },
-        "rdfa-streaming-parser": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-2.0.1.tgz",
-          "integrity": "sha512-7Yyaj030LO7iQ38Wh/RNLVeYrVFJeyx3dpCK7C1nvX55eIN/gE4HWfbg4BYI9X7Bd+eUIUMVeiKYLmYjV6apow==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "htmlparser2": "^8.0.0",
-            "rdf-data-factory": "^1.1.0",
-            "readable-stream": "^4.0.0",
-            "relative-to-absolute-iri": "^1.0.2"
-          }
-        },
-        "rdfxml-streaming-parser": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.2.1.tgz",
-          "integrity": "sha512-1r7aXfSRCLkBYXGcko/GpSZdHxXKvYaeUi2ulEbB7cLvACD7DNoAA/uW6dsETEhgmsEipJZI7NLqBl2whOse8Q==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/readable-stream": "^2.3.13",
-            "buffer": "^6.0.3",
-            "rdf-data-factory": "^1.1.0",
-            "readable-stream": "^4.0.0",
-            "relative-to-absolute-iri": "^1.0.0",
-            "saxes": "^6.0.0",
-            "validate-iri": "^1.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10"
-          }
-        },
-        "sparqlalgebrajs": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-          "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.3",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.6",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.6.1"
-          }
-        }
       }
     },
     "@digitalbazaar/http-client": {
@@ -16250,10 +14372,24 @@
         "uuid": "^9.0.0"
       }
     },
+    "@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
+    "@jeswr/prefixcc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jeswr/prefixcc/-/prefixcc-1.2.1.tgz",
+      "integrity": "sha512-kBBXbqsaeh3Irp416h/RbelqJgIOp6X/OJJlYmLyr/9qlBYKTKSCuEv5/xjZ0Yf8Yec+QFRYBaOQ2JkMBSH7KA==",
+      "requires": {
+        "cross-fetch": "^3.1.5",
+        "fsevents": "^2.3.2"
+      }
+    },
     "@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "peer": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.1",
@@ -16274,9 +14410,9 @@
       "peer": true
     },
     "@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
       "peer": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -16290,13 +14426,21 @@
       "peer": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
       "peer": true,
       "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "@koa/cors": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-3.4.3.tgz",
+      "integrity": "sha512-WPXQUaAeAMVaLTEFpoq3T2O1C+FstkjJnDQqy95Ck1UdILajsRhu6mhJ8H2f4NFPRBoCNN+qywTJfq/gGki5mw==",
+      "requires": {
+        "vary": "^1.1.2"
       }
     },
     "@nodelib/fs.scandir": {
@@ -16356,6 +14500,11 @@
           "requires": {
             "@rdfjs/to-ntriples": "^2.0.0"
           }
+        },
+        "@rdfjs/to-ntriples": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
+          "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q=="
         }
       }
     },
@@ -16407,6 +14556,18 @@
         "n3": "^1.3.5",
         "readable-stream": "^3.6.0",
         "readable-to-readable": "^0.1.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "@rdfjs/sink": {
@@ -16420,6 +14581,13 @@
       "integrity": "sha512-utCLVQEZdEL664XoYuBQwMIk0Q5MD6qNPEt12DcmuAlQUS0b0kQ+WL50wyJP1BpWYjOJLokIVTUtphZWnj25BQ==",
       "requires": {
         "@rdfjs/to-ntriples": "^2.0.0"
+      },
+      "dependencies": {
+        "@rdfjs/to-ntriples": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
+          "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q=="
+        }
       }
     },
     "@rdfjs/term-set": {
@@ -16428,12 +14596,19 @@
       "integrity": "sha512-QQ4yzVe1Rvae/GN9SnOhweHNpaxQtnAjeOVciP/yJ0Gfxtbphy2tM56ZsRLV04Qq5qMcSclZIe6irYyEzx/UwQ==",
       "requires": {
         "@rdfjs/to-ntriples": "^2.0.0"
+      },
+      "dependencies": {
+        "@rdfjs/to-ntriples": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
+          "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q=="
+        }
       }
     },
     "@rdfjs/to-ntriples": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
-      "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz",
+      "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA=="
     },
     "@rdfjs/types": {
       "version": "1.1.0",
@@ -16441,6 +14616,14 @@
       "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@rubensworks/saxes": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rubensworks/saxes/-/saxes-6.0.1.tgz",
+      "integrity": "sha512-UW4OTIsOtJ5KSXo2Tchi4lhZqu+tlHrOAs4nNti7CrtB53kAZl3/hyrTi6HkMihxdbDM6m2Zc3swc/ZewEe1xw==",
+      "requires": {
+        "xmlchars": "^2.2.0"
       }
     },
     "@rubensworks/solid-client-authn-isomorphic": {
@@ -16451,6 +14634,136 @@
         "@inrupt/solid-client-authn-browser": "^1.12.1",
         "@inrupt/solid-client-authn-core": "^1.12.1",
         "@inrupt/solid-client-authn-node": "^1.12.1"
+      }
+    },
+    "@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
+    },
+    "@solid/access-control-policy": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@solid/access-control-policy/-/access-control-policy-0.1.3.tgz",
+      "integrity": "sha512-LTxfN8N5hNBNYfuwJr0nyfxlp2P0+GeK+biCa1FQgIqska3wXpTgYaxjVgsw27mKx4N1FOlaGwG+nXdLnl9ykg=="
+    },
+    "@solid/access-token-verifier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@solid/access-token-verifier/-/access-token-verifier-2.0.5.tgz",
+      "integrity": "sha512-YsoMmEk7pN6tlCHcDm5iLa9ZYvTYvuk3SX5cz18XW1qYmM46znEGnXz94vm7DIa7DcTLGi9suMw7M5pRs2xOLw==",
+      "requires": {
+        "jose": "^4.10.3",
+        "lru-cache": "^6.0.0",
+        "n3": "^1.16.2",
+        "node-fetch": "^2.6.7",
+        "ts-guards": "^0.5.1"
+      }
+    },
+    "@solid/community-server": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@solid/community-server/-/community-server-6.0.1.tgz",
+      "integrity": "sha512-Ll/CokpMTjFAKt1QzmeEW8QPnzUaU/X1X/T8GwMcF9O3Da2qIWRU0negMN3DKFFVTuZK6Kj1swrFxOwbo29oRQ==",
+      "requires": {
+        "@comunica/context-entries": "^2.6.8",
+        "@comunica/query-sparql": "^2.6.9",
+        "@rdfjs/types": "^1.1.0",
+        "@solid/access-control-policy": "^0.1.3",
+        "@solid/access-token-verifier": "^2.0.5",
+        "@types/async-lock": "^1.4.0",
+        "@types/bcryptjs": "^2.4.2",
+        "@types/cors": "^2.8.12",
+        "@types/ejs": "^3.1.2",
+        "@types/end-of-stream": "^1.4.1",
+        "@types/fs-extra": "^11.0.1",
+        "@types/lodash.orderby": "^4.6.7",
+        "@types/marked": "^4.0.8",
+        "@types/mime-types": "^2.1.1",
+        "@types/n3": "^1.10.4",
+        "@types/node": "^14.18.43",
+        "@types/nodemailer": "^6.4.7",
+        "@types/oidc-provider": "^7.11.1",
+        "@types/proper-lockfile": "^4.1.2",
+        "@types/pump": "^1.1.1",
+        "@types/punycode": "^2.1.0",
+        "@types/rdf-validate-shacl": "^0.4.1",
+        "@types/sparqljs": "^3.1.4",
+        "@types/url-join": "^4.0.1",
+        "@types/uuid": "^9.0.1",
+        "@types/ws": "^8.5.4",
+        "@types/yargs": "^17.0.24",
+        "arrayify-stream": "^2.0.1",
+        "async-lock": "^1.4.0",
+        "bcryptjs": "^2.4.3",
+        "componentsjs": "^5.3.2",
+        "cors": "^2.8.5",
+        "cross-fetch": "^3.1.5",
+        "ejs": "^3.1.9",
+        "end-of-stream": "^1.4.4",
+        "escape-string-regexp": "^4.0.0",
+        "fetch-sparql-endpoint": "^3.2.1",
+        "fs-extra": "^11.1.1",
+        "handlebars": "^4.7.7",
+        "ioredis": "^5.3.2",
+        "iso8601-duration": "^2.1.1",
+        "jose": "^4.14.1",
+        "jsonld-context-parser": "^2.3.0",
+        "lodash.orderby": "^4.6.0",
+        "marked": "^4.3.0",
+        "mime-types": "^2.1.35",
+        "n3": "^1.16.4",
+        "nodemailer": "^6.9.1",
+        "oidc-provider": "7.10.6",
+        "proper-lockfile": "^4.1.2",
+        "pump": "^3.0.0",
+        "punycode": "^2.1.1",
+        "rdf-dereference": "^2.1.0",
+        "rdf-parse": "^2.3.2",
+        "rdf-serialize": "^2.2.2",
+        "rdf-string": "^1.6.3",
+        "rdf-terms": "^1.9.1",
+        "rdf-validate-shacl": "^0.4.5",
+        "sparqlalgebrajs": "^4.0.5",
+        "sparqljs": "^3.6.2",
+        "url-join": "^4.0.1",
+        "uuid": "^9.0.0",
+        "winston": "^3.8.2",
+        "winston-transport": "^4.5.0",
+        "ws": "^8.13.0",
+        "yargs": "^17.7.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.18.53",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.53.tgz",
+          "integrity": "sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A=="
+        },
+        "@types/uuid": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+          "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "fs-extra": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "requires": {
+        "defer-to-connect": "^2.0.0"
       }
     },
     "@tpluscode/rdf-ns-builders": {
@@ -16473,47 +14786,47 @@
       }
     },
     "@tpluscode/rdf-string": {
-      "version": "0.2.26",
-      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-string/-/rdf-string-0.2.26.tgz",
-      "integrity": "sha512-zfNGMmY8D9jVuJ9qHwNrIWMwhibIkO42/1KtCfo59m4vXYTfJrXcn1ny9pj5kuhbpSubRbJ69zmYxP4UrXVPQw==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-string/-/rdf-string-0.2.27.tgz",
+      "integrity": "sha512-+h7FdEE9AwP+B0kA2u0lScWq0+wIfpAcsau6cHZRQfToTCQjq+xo5eyGqzC96SmVfULl73DHys5DE/VOtA3Ewg==",
       "requires": {
         "@rdf-esm/data-model": "^0.5.3",
         "@rdf-esm/term-map": "^0.5.0",
         "@rdfjs/types": "*",
         "@tpluscode/rdf-ns-builders": "^2",
-        "@zazuko/rdf-vocabularies": "*"
+        "@zazuko/rdf-vocabularies": ">=2023.01.17"
       }
     },
     "@treecg/actor-init-ldes-client": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@treecg/actor-init-ldes-client/-/actor-init-ldes-client-2.6.0.tgz",
-      "integrity": "sha512-0KfIMwKKVgqgJb6b+Uf3YRACArdGCIWKDBlGNKkzSRbe0ShKBZ2XDMbMA6PgM/oxELEAImTcDXKQUvzBwdK8Rg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@treecg/actor-init-ldes-client/-/actor-init-ldes-client-3.0.2.tgz",
+      "integrity": "sha512-vkYU14GS8ZePkUDoniuRMT7puKc+iyEf1TlIr8XG82uYhyQnhP5dPNG3Z5lylbWDBwVxRb1eY+5rIc31zJOI4g==",
       "requires": {
-        "@comunica/actor-http-node-fetch": "1.21.2",
-        "@comunica/actor-http-proxy": "1.21.1",
-        "@comunica/actor-init-sparql": "1.21.3",
-        "@comunica/actor-rdf-dereference-http-parse": "1.21.2",
-        "@comunica/actor-rdf-parse-jsonld": "1.21.2",
-        "@comunica/actor-rdf-parse-n3": "1.21.1",
-        "@comunica/bus-http": "1.21.1",
-        "@comunica/bus-init": "1.21.1",
-        "@comunica/bus-rdf-dereference": "1.21.1",
-        "@comunica/bus-rdf-metadata-extract": "1.21.1",
-        "@comunica/bus-rdf-parse": "1.21.1",
-        "@comunica/core": "1.21.1",
-        "@comunica/mediator-combine-union": "1.21.1",
-        "@comunica/mediator-number": "1.21.1",
-        "@comunica/mediator-race": "1.21.1",
-        "@comunica/runner": "1.21.1",
-        "@comunica/runner-cli": "1.21.1",
-        "@dexagod/rdf-retrieval": "^1.0.2",
-        "@rdfjs/data-model": "1.3.3",
-        "@treecg/actor-rdf-filter-object-with-framing": "^2.3.6",
-        "@treecg/actor-rdf-filter-objects-with-quadstore": "^2.3.6",
-        "@treecg/actor-rdf-frame-with-json-ld-js": "^2.6.0",
-        "@treecg/actor-rdf-metadata-extract-tree": "^1.20.0",
-        "@treecg/bus-rdf-filter-object": "^2.3.6",
-        "@treecg/bus-rdf-frame": "^2.6.0",
+        "@comunica/actor-dereference-rdf-parse": "^2.3.0",
+        "@comunica/actor-http-fetch": "^2.3.0",
+        "@comunica/actor-http-proxy": "^2.3.0",
+        "@comunica/actor-rdf-parse-jsonld": "^2.3.0",
+        "@comunica/actor-rdf-parse-n3": "^2.3.0",
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-init": "^2.3.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/mediator-combine-union": "^2.3.0",
+        "@comunica/mediator-number": "^2.3.0",
+        "@comunica/mediator-race": "^2.3.0",
+        "@comunica/query-sparql": "^2.3.0",
+        "@comunica/runner": "^2.3.0",
+        "@comunica/runner-cli": "^2.3.0",
+        "@dexagod/rdf-retrieval": "^1.0.3",
+        "@rdfjs/data-model": "^2.0.1",
+        "@treecg/actor-rdf-filter-object-with-framing": "^3.0.0",
+        "@treecg/actor-rdf-filter-objects-with-quadstore": "^3.0.0",
+        "@treecg/actor-rdf-frame-with-json-ld-js": "^3.0.0",
+        "@treecg/actor-rdf-metadata-extract-tree": "^2.0.0",
+        "@treecg/bus-rdf-filter-object": "^3.0.0",
+        "@treecg/bus-rdf-frame": "^3.0.0",
         "@treecg/types": "^0.2.2",
         "awesome-typescript-loader": "^5.2.1",
         "cacheable-request": "^7.0.1",
@@ -16523,54 +14836,65 @@
         "lru-cache": "^6.0.0",
         "moment": "^2.29.1",
         "n3": "^1.8.0",
-        "rdf-dereference": "^1.8.0",
+        "rdf-dereference": "^2.0.0",
         "rdf-string": "^1.6.0",
         "source-map-loader": "^2.0.0",
         "streamify-string": "^1.0.1",
-        "typescript": "^4.1.3"
+        "typescript": "^4.7.4"
       },
       "dependencies": {
         "@rdfjs/data-model": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.3.tgz",
-          "integrity": "sha512-oo9U3nEowTxxML7CZybujL3e/bty4aXHDSWanWXQxfnJQYKU6p5SCgkjeRbuVfQ9lAVfdvz68Qq5D4LtGWuKug==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
+          "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw=="
+        },
+        "@treecg/types": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/@treecg/types/-/types-0.2.5.tgz",
+          "integrity": "sha512-sIY++4YL4QCWisq/8YozbqMQpomHDkZmw3qoWy/7bSSlwaSVks8g0Zwfv92IALWz9Lq1EtRqyv3jAaCyDtctkw==",
           "requires": {
-            "@types/rdf-js": "*"
+            "@rdfjs/dataset": "^1.1.1",
+            "@rdfjs/types": "*",
+            "@types/node": "*",
+            "clownface": "^1.4.0",
+            "clownface-shacl-path": "^1.2.2",
+            "loglevel": "^1.8.0",
+            "loglevel-plugin-prefix": "^0.8.4",
+            "n3": "^1.11.1",
+            "rdf-data-factory": "^1.1.0",
+            "winston": "^3.3.3"
           }
-        },
-        "@treecg/bus-rdf-filter-object": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-filter-object/-/bus-rdf-filter-object-2.3.6.tgz",
-          "integrity": "sha512-sIHoQvOG1ElVaNe5M44Za5gV0Q1aQNvt975+cFyjzRCTcqdoCLUPOfEZwpBdqgvbbyOFphUj8ytfKOng/xQ/iw==",
-          "requires": {}
-        },
-        "@treecg/bus-rdf-frame": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-frame/-/bus-rdf-frame-2.6.0.tgz",
-          "integrity": "sha512-n44CYCbzie37WtIia1PoBMJi8aYan5hUbKh9dbF6MTF9GJ3Tc5bnNRDOvG8bhK61FjFD924SWNm82v34w1/R1w==",
-          "requires": {}
         }
       }
     },
     "@treecg/actor-rdf-filter-object-with-framing": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-filter-object-with-framing/-/actor-rdf-filter-object-with-framing-2.3.6.tgz",
-      "integrity": "sha512-wv6HEPbenyH/UhjpPrC0n6VS1IFWYiik3LcfO7E0fmHl6mzZMaK/rYuVGH6uYaq2nJBOCoUbpoVHYeOIsjII+w==",
-      "requires": {}
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-filter-object-with-framing/-/actor-rdf-filter-object-with-framing-3.0.0.tgz",
+      "integrity": "sha512-aRn7R+nTyxVcdiJL7O8Y12Ea5Ek3y+fEMyupMV1a11NwtLq0o5esQ8T2HglOqW2TD9tkTnxEPChLtlFaGJjriQ==",
+      "requires": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@treecg/bus-rdf-filter-object": "^3.0.0",
+        "@treecg/bus-rdf-frame": "^3.0.0",
+        "@types/rdf-js": "^4.0.2"
+      }
     },
     "@treecg/actor-rdf-filter-objects-with-quadstore": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-filter-objects-with-quadstore/-/actor-rdf-filter-objects-with-quadstore-2.3.6.tgz",
-      "integrity": "sha512-bkT6yD0tfoj7k4VCQ1AaCA6NSVDgzzWaK20te3e7ikg7nu+m89AV/7rkuJgyqJp8BfVUQj6kuzrhY9b/jdJsuA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-filter-objects-with-quadstore/-/actor-rdf-filter-objects-with-quadstore-3.0.0.tgz",
+      "integrity": "sha512-nruV/Y5rPXkDm1GF4sOwkJBL4+cGDRaX3PXukG5xY1z+e772b8V4j7Y0HQaJMPo4tW4aPTwUbJNbtjA3DEjDfg==",
       "requires": {
+        "@comunica/core": "^2.3.0",
+        "@treecg/bus-rdf-filter-object": "^3.0.0",
+        "@types/rdf-js": "^4.0.2",
         "n3": "^1.10.0",
         "rdf-store-stream": "^1.2.0"
       }
     },
     "@treecg/actor-rdf-frame-with-json-ld-js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-frame-with-json-ld-js/-/actor-rdf-frame-with-json-ld-js-2.6.0.tgz",
-      "integrity": "sha512-Y/1ypXzGJpxRPX0PMf1xYS1yYa804VY+JAimfTIgwjhdIVroLtwvxH+UZ3Xch99ksI/U/9F1vowe2Y2d/ksy/g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-frame-with-json-ld-js/-/actor-rdf-frame-with-json-ld-js-3.0.0.tgz",
+      "integrity": "sha512-H+4DeQ8CHgnSLjIcHqhxplkysHNHTTySRL4fy6o13zcWcF211U1jdpHrfBYwtv3qiJJvy4XTkV7pxC3UEhC7gQ==",
       "requires": {
         "@types/jsonld": "^1.5.4",
         "jsonld": "^4.0.1",
@@ -16620,40 +14944,51 @@
       }
     },
     "@treecg/actor-rdf-metadata-extract-tree": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-metadata-extract-tree/-/actor-rdf-metadata-extract-tree-1.20.0.tgz",
-      "integrity": "sha512-BUAbTsHczPR0GbAMznxIgzKm9BqB6B2Q9TQeNjsqDHpfVe0NffggGk3ma/P1XrerL+NsAxO5AS2z76MZtzFpBw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-metadata-extract-tree/-/actor-rdf-metadata-extract-tree-2.0.0.tgz",
+      "integrity": "sha512-15ysrCQ2vx+UN1yCtx9g4T6nj7QiHjPDd/r/KUwcrdTzTktz/z3bOSIojxugMCW6PrxxUqTEVx5I506TSamq8A==",
       "requires": {
-        "@comunica/bus-rdf-metadata-extract": "1.21.1",
-        "@comunica/core": "1.21.1",
-        "@treecg/tree-metadata-extraction": "^1.1.1"
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@treecg/tree-metadata-extraction": "^1.2.1",
+        "typescript": "^4.7.4"
       }
     },
     "@treecg/bus-rdf-filter-object": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-filter-object/-/bus-rdf-filter-object-2.3.4.tgz",
-      "integrity": "sha512-ctNZcWxttC9bOiD1E2+fAl6RJeaBrI2wyg9YHoYrGU2/pXzFqK3PzuqPyxe0LcBtnbKnw++SrkzNwDCNlqvCNQ==",
-      "peer": true,
-      "requires": {}
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-filter-object/-/bus-rdf-filter-object-3.0.0.tgz",
+      "integrity": "sha512-j0xDopxWwfK8RamhisWYCXtFmZDwOcQfYgy8WG6b3D2Hj3INGK1dN1rSLOz8O+UEEKfA6mwmc6hQpPHwkdq3Pg==",
+      "requires": {
+        "@comunica/core": "^2.3.0"
+      }
     },
     "@treecg/bus-rdf-frame": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-frame/-/bus-rdf-frame-2.3.4.tgz",
-      "integrity": "sha512-ZBBEkKt039bwiE4/cQdjtcOU8yE2TThrs7RkBuqDQEEfFngcafNkHoin1DO1sC2vIZTZiGOq1/t1I4fgu0uyBA==",
-      "peer": true,
-      "requires": {}
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-frame/-/bus-rdf-frame-3.0.0.tgz",
+      "integrity": "sha512-rFM5ZM2jn04erD3uLYmxY0CVlssFaUlv7Bpr5pxJM9MWC1gA9xwjOMls1aAggjaZIE+YeA+j7E0ZnVoYBMdujg==",
+      "requires": {
+        "@comunica/core": "^2.3.0"
+      }
     },
     "@treecg/ldes-snapshot": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@treecg/ldes-snapshot/-/ldes-snapshot-0.0.5.tgz",
-      "integrity": "sha512-J5F27eWkZwmJyi9AKtLdIhrZ3U+ARSsotuEIc2PXuKzJtux1oaSX5hQhNDyvpnvEEZccanafS7U/5qJC4W9EPw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@treecg/ldes-snapshot/-/ldes-snapshot-0.1.1.tgz",
+      "integrity": "sha512-cYt68FCgjg5M9JbRHyIzL5M01UhuwouMVTdbA4Vct5V89KwPopYUwhLbOmN4z88tHqbzo/WZWw0QZ98Sgx1Ldw==",
       "requires": {
-        "@treecg/version-materialize-rdf.js": "^0.0.2",
+        "@rdfjs/data-model": "^2.0.1",
+        "@treecg/version-materialize-rdf.js": "^0.0.3",
         "loglevel": "^1.8.0",
         "loglevel-plugin-prefix": "^0.8.4",
         "n3": "^1.13.0",
-        "rdf-parse": "^1.9.1",
+        "rdf-parse": "^2.3.0",
         "typescript": "^4.6.2"
+      },
+      "dependencies": {
+        "@rdfjs/data-model": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
+          "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw=="
+        }
       }
     },
     "@treecg/tree-metadata-extraction": {
@@ -16665,52 +15000,50 @@
       }
     },
     "@treecg/types": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@treecg/types/-/types-0.2.5.tgz",
-      "integrity": "sha512-sIY++4YL4QCWisq/8YozbqMQpomHDkZmw3qoWy/7bSSlwaSVks8g0Zwfv92IALWz9Lq1EtRqyv3jAaCyDtctkw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@treecg/types/-/types-0.4.5.tgz",
+      "integrity": "sha512-vPEVVlRDPQz8KwQmC6SKW5cTgggrBmEapw1Plg7beVX6pmfM1bll7lMnHGNLJDmoDyfAkR6LV4nB/VLGpjGBPA==",
       "requires": {
-        "@rdfjs/dataset": "^1.1.1",
         "@rdfjs/types": "*",
-        "@types/node": "*",
-        "clownface": "^1.4.0",
-        "clownface-shacl-path": "^1.2.2",
-        "loglevel": "^1.8.0",
+        "loglevel": "^1.8.1",
         "loglevel-plugin-prefix": "^0.8.4",
-        "n3": "^1.11.1",
-        "rdf-data-factory": "^1.1.0",
-        "winston": "^3.3.3"
+        "rdf-data-factory": "^1.1.0"
       }
     },
     "@treecg/version-materialize-rdf.js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@treecg/version-materialize-rdf.js/-/version-materialize-rdf.js-0.0.2.tgz",
-      "integrity": "sha512-A4XzscAE4+P9JmfIYe1pTmJfdTFtA+PyJ1XwBNIKps7lZ4AOaZPTCufUcH90ltkkiTOxoFqK5PLhfehxDwAlhw==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@treecg/version-materialize-rdf.js/-/version-materialize-rdf.js-0.0.3.tgz",
+      "integrity": "sha512-yPNiW0YP2JhuxaV3i6ltSDxWfrAyfSn0UspsiUjASPWn8JIhr/aF0P7mF3aFm5/AILCaBkuxSV4ibNvQLOElDw==",
       "requires": {
-        "@treecg/actor-init-ldes-client": "^2.3.7",
+        "@treecg/actor-init-ldes-client": "^3.0.1",
         "commander": "^8.1.0",
         "rdf-data-factory": "^1.1.0"
       }
     },
     "@treecg/versionawareldesinldp": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@treecg/versionawareldesinldp/-/versionawareldesinldp-0.0.2.tgz",
-      "integrity": "sha512-DtLjQsocoU6E9wlqXm23PTcUm7ZKpcISQY+UHMW7SRtBVN3tgMv10xtqiLo8qhGgw5iI1cZNcvz2ssHxUUH+/w==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@treecg/versionawareldesinldp/-/versionawareldesinldp-0.2.1.tgz",
+      "integrity": "sha512-XFEMzCqnWJ5gmB/3D6ZeUrzf3iN3DmhE8XOn8UadbkdnCmyV5BW5hs+4LaXwaUC+wTFM6XYat0W6CpVKOTPd9w==",
       "requires": {
         "@inrupt/solid-client-authn-node": "1.12.1",
         "@rdfjs/data-model": "^1.3.4",
-        "@rubensworks/solid-client-authn-isomorphic": "^1.0.0",
-        "@treecg/ldes-snapshot": "^0.0.5",
-        "@treecg/types": "^0.2.2",
-        "componentsjs": "^4.5.0",
-        "componentsjs-generator": "^2.6.1",
+        "@rubensworks/solid-client-authn-isomorphic": "^2.0.0",
+        "@treecg/ldes-snapshot": "^0.1.1",
+        "@treecg/types": "^0.4.0",
+        "componentsjs": "^5.3.2",
+        "componentsjs-generator": "^3.1.0",
         "dotenv": "^16.0.1",
+        "express": "^4.17.3",
         "loglevel": "^1.8.0",
         "loglevel-plugin-prefix": "^0.8.4",
         "n3": "^1.14.0",
-        "rdf-store-stream": "^1.3.0",
+        "parse-link-header": "^2.0.0",
+        "rdf-store-stream": "^1.3.1",
         "streamify-string": "^1.0.1",
+        "tinyduration": "^3.2.3",
         "typescript": "^4.6.2",
         "uuid": "^8.3.2",
+        "wac-allow": "^1.0.0",
         "yargs": "^17.4.1"
       },
       "dependencies": {
@@ -16726,16 +15059,6 @@
             "uuid": "^8.3.2"
           }
         },
-        "@rubensworks/solid-client-authn-isomorphic": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@rubensworks/solid-client-authn-isomorphic/-/solid-client-authn-isomorphic-1.0.0.tgz",
-          "integrity": "sha512-Wv6teAK4u8efRl6GVGofp542+ljGl6RvvR/l/buCDAZ/07zlSEXzXWEprMWcGN5SHkeZaAHMq2rVVR5RGZ2Fyw==",
-          "requires": {
-            "@inrupt/solid-client-authn-browser": "^1.11.2",
-            "@inrupt/solid-client-authn-core": "^1.11.2",
-            "@inrupt/solid-client-authn-node": "^1.11.2"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -16744,14 +15067,14 @@
       }
     },
     "@ts-morph/common": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.18.1.tgz",
-      "integrity": "sha512-RVE+zSRICWRsfrkAw5qCAK+4ZH9kwEFv5h0+/YeHTLieWP7F4wWq4JsKFuNWG+fYh/KF+8rAtgdj5zb2mm+DVA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.20.0.tgz",
+      "integrity": "sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==",
       "peer": true,
       "requires": {
         "fast-glob": "^3.2.12",
-        "minimatch": "^5.1.0",
-        "mkdirp": "^1.0.4",
+        "minimatch": "^7.4.3",
+        "mkdirp": "^2.1.6",
         "path-browserify": "^1.0.1"
       },
       "dependencies": {
@@ -16765,18 +15088,18 @@
           }
         },
         "minimatch": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-          "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+          "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
           "peer": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
         },
         "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+          "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
           "peer": true
         }
       }
@@ -16800,16 +15123,33 @@
       "peer": true
     },
     "@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "peer": true
+    },
+    "@types/accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/async-lock": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.0.tgz",
+      "integrity": "sha512-2+rYSaWrpdbQG3SA0LmMT6YxWLrI81AqpMlSkw3QtFc2HGDufkweQSn30Eiev7x9LL0oyFrBqk1PXOnB9IEgKg=="
+    },
+    "@types/bcryptjs": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
+      "integrity": "sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ=="
     },
     "@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -16820,19 +15160,74 @@
       "resolved": "https://registry.npmjs.org/@types/browser-or-node/-/browser-or-node-1.3.0.tgz",
       "integrity": "sha512-MVetr65IR7RdJbUxVHsaPFaXAO8fi89zv1g8L/mHygh1Q7xnnK02XZLwfMh57FOpTO6gtnagoPMQ/UOFfctXRQ=="
     },
+    "@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "@types/clownface": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/clownface/-/clownface-1.5.2.tgz",
+      "integrity": "sha512-c/BLyUFSuzgmbQ0kBlxNf9HEkDdCk4tMxUxWjtGSpvLMXM3t5KrJabcGkDStmfzA+bHFHwHHikyWsZYVC1TuWw==",
+      "requires": {
+        "rdf-js": "^4.0.2"
+      }
+    },
     "@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/content-disposition": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
+      "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA=="
+    },
+    "@types/cookies": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
+      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/ejs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.2.tgz",
+      "integrity": "sha512-ZmiaE3wglXVWBM9fyVC17aGPkLo/UgaOjEiI2FXQfyczrCefORPxIe+2dVmnmk3zkVIbizjrlQzmPGhSYGXG5g=="
+    },
+    "@types/end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@types/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-dYCSlUtCGXuP2axeKD5l1vj/04iNXW8TLXryDa0uA8u8EsNE68jn27ZLg7jAPV+qJAlk1wC4WtRdIoZXvuUl0A==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/eslint": {
-      "version": "8.4.10",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
-      "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
+      "version": "8.40.2",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.2.tgz",
+      "integrity": "sha512-PRVjQ4Eh9z9pmmtaq8nTjZjQwKFk7YIHIud3lRoKRBgUQjgjRmoGxxGEPXQkF+lH7QkHJRNr5F4aBgYCW0lqpQ==",
       "peer": true,
       "requires": {
         "@types/estree": "*",
@@ -16850,16 +15245,15 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
       "peer": true
     },
     "@types/express": {
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
       "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
-      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -16871,12 +15265,35 @@
       "version": "4.17.31",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
       "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "@types/fs-extra": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.1.tgz",
+      "integrity": "sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==",
+      "requires": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/http-assert": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.3.tgz",
+      "integrity": "sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA=="
+    },
+    "@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
+    "@types/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
     },
     "@types/http-link-header": {
       "version": "1.0.3",
@@ -16891,10 +15308,54 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
+    "@types/jsonfile": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.1.tgz",
+      "integrity": "sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/jsonld": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.8.tgz",
-      "integrity": "sha512-4l5t/jDnJpqZ+i7CLTTgPcT5BYXnAnwJupb07aAokPufCV0SjDHcwctUkSTuhIuSU9yHok+WOOngIGCtpL96gw=="
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.9.tgz",
+      "integrity": "sha512-K76ImkErPYL2wGPZpNFSKp6wE+h/APecZLJrU7UfDaGqt/f+D9Rrg1aR7VdRrQ6k5DUNRZ2vn9yACwmpOr9QcA=="
+    },
+    "@types/keygrip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
+    },
+    "@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/koa": {
+      "version": "2.13.6",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.6.tgz",
+      "integrity": "sha512-diYUfp/GqfWBAiwxHtYJ/FQYIXhlEhlyaU7lB/bWQrx4Il9lCET5UwpFy3StOAohfsxxvEQ11qIJgT1j2tfBvw==",
+      "requires": {
+        "@types/accepts": "*",
+        "@types/content-disposition": "*",
+        "@types/cookies": "*",
+        "@types/http-assert": "*",
+        "@types/http-errors": "*",
+        "@types/keygrip": "*",
+        "@types/koa-compose": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/koa-compose": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
+      "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
+      "requires": {
+        "@types/koa": "*"
+      }
     },
     "@types/lodash": {
       "version": "4.14.191",
@@ -16909,16 +15370,36 @@
         "@types/lodash": "*"
       }
     },
+    "@types/lodash.orderby": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.orderby/-/lodash.orderby-4.6.7.tgz",
+      "integrity": "sha512-GaaUBTS4RTjL8gz1ZXkwAB/defpGMOWwCG9C4HL9g81i4wghIoVVESQCUa1xRsyUBqAb5JwLbSwvL0q36rK0sA==",
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+      "version": "7.10.10",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-7.10.10.tgz",
+      "integrity": "sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==",
+      "requires": {
+        "lru-cache": "*"
+      }
+    },
+    "@types/marked": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.1.tgz",
+      "integrity": "sha512-vSSbKZFbNktrQ15v7o1EaH78EbWV+sPQbPjHG+Cp8CaNcPFUEfjZ0Iml/V0bFDwsTlYe8o6XC5Hfdp91cqPV2g=="
     },
     "@types/mime": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-      "dev": true
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
+    },
+    "@types/mime-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.1.tgz",
+      "integrity": "sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw=="
     },
     "@types/minimist": {
       "version": "1.2.2",
@@ -16939,22 +15420,52 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.14.tgz",
       "integrity": "sha512-0KXV57tENYmmJMl+FekeW9V3O/rlcqGQQJ/hNh9r8pKIj304pskWuEd8fCyNT86g/TpO0gcOTiLzsHLEURFMIQ=="
     },
-    "@types/parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha512-E2+Go9rQgPbmpkeA2iFXTWSTxX38KXlXwcdiIbt71Oorqr+G5QtH4AhpuDdxwRVyiTzdUrHnaaIumW/LhiZwVg=="
+    "@types/nodemailer": {
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.8.tgz",
+      "integrity": "sha512-oVsJSCkqViCn8/pEu2hfjwVO+Gb3e+eTWjg3PcjeFKRItfKpKwHphQqbYmPQrlMk+op7pNNWPbsJIEthpFN/OQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/oidc-provider": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@types/oidc-provider/-/oidc-provider-7.14.0.tgz",
+      "integrity": "sha512-zIoedB25LuuiNb0tqRQYI3BzdHXVCsZrCHm38apiLe1p6TmbZA7dCSv8rH3AR8xyBk7eNiE+iIBDEHlBx4UzPA==",
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
+    "@types/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-kd4LMvcnpYkspDcp7rmXKedn8iJSCoa331zRRamUp5oanKt/CefbEGPQP7G89enz7sKD4bvsr8mHSsC8j5WOvA==",
+      "requires": {
+        "@types/retry": "*"
+      }
+    },
+    "@types/pump": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/pump/-/pump-1.1.1.tgz",
+      "integrity": "sha512-wpRerjHDxFBQ4r8XNv3xHJZeuqrBBoeQ/fhgkooV2F7KsPIYRROb/+f9ODgZfOEyO5/w2ej4YQdpPPXipT8DAA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha512-PG5aLpW6PJOeV2fHRslP4IOMWn+G+Uq8CfnyJ+PDS8ndCbU+soO+fB3NKCKo0p/Jh2Y4aPaiQZsrOXFdzpcA6g=="
     },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/rdf-dataset-indexed": {
       "version": "0.4.6",
@@ -16981,6 +15492,15 @@
         "rdf-js": "*"
       }
     },
+    "@types/rdf-validate-shacl": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@types/rdf-validate-shacl/-/rdf-validate-shacl-0.4.2.tgz",
+      "integrity": "sha512-txAtt8VBUMp6tO41aeJtbf6sgvM1n1LTC7rhmfO9ili7eoAe0wlNXGjo+1RLtb9pHWe9s2SnRAxFFbOY5A5I/A==",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/clownface": "*"
+      }
+    },
     "@types/rdfjs__dataset": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-1.0.5.tgz",
@@ -16990,11 +15510,11 @@
       }
     },
     "@types/rdfjs__namespace": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.0.tgz",
-      "integrity": "sha512-bpVmmBrwg4plwfSNtwbwIYtZEpGFPWHTlfa1iftSY03+V+2wq+pfZxYkZwrhZwyh/Dxy5usIrVt04Rvigc4uXg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.3.tgz",
+      "integrity": "sha512-qJ8KpDby8p6STR8ZeDrhVDfzAnwII0txlrLhCsZz/V+3Mbsz0GzUiY8654ENzCicbjd+ZY8PNiS2fHZ/evY3Dw==",
       "requires": {
-        "rdf-js": "^4.0.2"
+        "@rdfjs/types": "*"
       }
     },
     "@types/readable-stream": {
@@ -17013,6 +15533,19 @@
         }
       }
     },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="
+    },
     "@types/semver": {
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
@@ -17022,7 +15555,6 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
       "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
-      "dev": true,
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -17034,35 +15566,45 @@
       "integrity": "sha512-82E/lVRaqelV9qmRzzJ1PKTpyrpnT7mwdneKNJB9hUtypZDMggloDfFUCIqRRx3lYRxteCwXSq9c+W71Vf0QnQ=="
     },
     "@types/sparqljs": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.3.tgz",
-      "integrity": "sha512-nmFgmR6ns4i8sg9fYu+293H+PMLKmDOZy34sgwgAeUEEiIqSs4guj5aCZRt3gq1g0yuKXkqrxLDq/684g7pGtQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.4.tgz",
+      "integrity": "sha512-0MvCTEfveYJDkI91olLcDf/F3wMMbsxwNxiNZeglt4tbIFULd9pRpcacj1MuA+acFDkTnPXS9L7OqZNn/W1MAg==",
       "requires": {
         "rdf-js": "^4.0.2"
       }
+    },
+    "@types/triple-beam": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
+      "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g=="
     },
     "@types/uritemplate": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@types/uritemplate/-/uritemplate-0.3.4.tgz",
       "integrity": "sha512-1D8mJEeQEXynoPQKJkneIK+tXaM2Qnk6c80RBQPV/O2ToypI4mlqXy5jojnYKjTX2Q+EMNMOWt0wNdLbb2MUpA=="
     },
+    "@types/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ=="
+    },
     "@types/uuid": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
-    "@types/xml": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/xml/-/xml-1.0.8.tgz",
-      "integrity": "sha512-IptEZBtDwSPayCP8FmbordhAdjdxsif4zH29xTbBRacZeCHFHZp8OxyG1/CrS8AS0MziJUPTGWCTKbYtvHGYPg==",
+    "@types/ws": {
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/yargs": {
-      "version": "17.0.17",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
-      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -17126,14 +15668,12 @@
     "@typescript-eslint/types": {
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
-      "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
-      "dev": true
+      "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w=="
     },
     "@typescript-eslint/typescript-estree": {
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
       "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
-      "dev": true,
       "requires": {
         "@typescript-eslint/types": "5.46.1",
         "@typescript-eslint/visitor-keys": "5.46.1",
@@ -17164,155 +15704,154 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
       "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
-      "dev": true,
       "requires": {
         "@typescript-eslint/types": "5.46.1",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
     "@webassemblyjs/ast": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
+      "integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
       "peer": true,
       "requires": {
-        "@webassemblyjs/helper-numbers": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+        "@webassemblyjs/helper-numbers": "1.11.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
       "peer": true
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
       "peer": true
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
+      "integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
       "peer": true
     },
     "@webassemblyjs/helper-numbers": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
       "peer": true,
       "requires": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.1",
-        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
+        "@webassemblyjs/helper-api-error": "1.11.6",
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
       "peer": true
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
+      "integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
       "peer": true,
       "requires": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-buffer": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/wasm-gen": "1.11.1"
+        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/helper-buffer": "1.11.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+        "@webassemblyjs/wasm-gen": "1.11.6"
       }
     },
     "@webassemblyjs/ieee754": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
       "peer": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
       "peer": true,
       "requires": {
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
       "peer": true
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
+      "integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
       "peer": true,
       "requires": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-buffer": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/helper-wasm-section": "1.11.1",
-        "@webassemblyjs/wasm-gen": "1.11.1",
-        "@webassemblyjs/wasm-opt": "1.11.1",
-        "@webassemblyjs/wasm-parser": "1.11.1",
-        "@webassemblyjs/wast-printer": "1.11.1"
+        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/helper-buffer": "1.11.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+        "@webassemblyjs/helper-wasm-section": "1.11.6",
+        "@webassemblyjs/wasm-gen": "1.11.6",
+        "@webassemblyjs/wasm-opt": "1.11.6",
+        "@webassemblyjs/wasm-parser": "1.11.6",
+        "@webassemblyjs/wast-printer": "1.11.6"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
+      "integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
       "peer": true,
       "requires": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/ieee754": "1.11.1",
-        "@webassemblyjs/leb128": "1.11.1",
-        "@webassemblyjs/utf8": "1.11.1"
+        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+        "@webassemblyjs/ieee754": "1.11.6",
+        "@webassemblyjs/leb128": "1.11.6",
+        "@webassemblyjs/utf8": "1.11.6"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
+      "integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
       "peer": true,
       "requires": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-buffer": "1.11.1",
-        "@webassemblyjs/wasm-gen": "1.11.1",
-        "@webassemblyjs/wasm-parser": "1.11.1"
+        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/helper-buffer": "1.11.6",
+        "@webassemblyjs/wasm-gen": "1.11.6",
+        "@webassemblyjs/wasm-parser": "1.11.6"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
+      "integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
       "peer": true,
       "requires": {
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/helper-api-error": "1.11.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-        "@webassemblyjs/ieee754": "1.11.1",
-        "@webassemblyjs/leb128": "1.11.1",
-        "@webassemblyjs/utf8": "1.11.1"
+        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/helper-api-error": "1.11.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+        "@webassemblyjs/ieee754": "1.11.6",
+        "@webassemblyjs/leb128": "1.11.6",
+        "@webassemblyjs/utf8": "1.11.6"
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
+      "integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
       "peer": true,
       "requires": {
-        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/ast": "1.11.6",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -17329,9 +15868,9 @@
       "peer": true
     },
     "@zazuko/rdf-vocabularies": {
-      "version": "2022.11.28",
-      "resolved": "https://registry.npmjs.org/@zazuko/rdf-vocabularies/-/rdf-vocabularies-2022.11.28.tgz",
-      "integrity": "sha512-fg3GwDMI2ooS6VA2C23hFy5BrY5WO4lwjwa0/jYLYUpEHorTk430X0MvKQcfEgyz6U4NO8QDS8jz1CGvC4YLAw==",
+      "version": "2023.1.19",
+      "resolved": "https://registry.npmjs.org/@zazuko/rdf-vocabularies/-/rdf-vocabularies-2023.1.19.tgz",
+      "integrity": "sha512-/vC/Ok8etIi4kflbOAoRr9JV95auJaUREV9lrWP3wDEMfhu8jVYogwi/OD1yA2pH6KIYPS2+z7LN1jxOe3G56g==",
       "requires": {
         "@rdfjs/parser-n3": "^1.1.4",
         "commander": "^5.0.0",
@@ -17345,6 +15884,16 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
           "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+        },
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         }
       }
     },
@@ -17446,6 +15995,15 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q=="
     },
+    "array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      }
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -17462,9 +16020,9 @@
       "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ=="
     },
     "arrayify-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/arrayify-stream/-/arrayify-stream-1.0.0.tgz",
-      "integrity": "sha512-RP80ep76Lbew2wWN5ogrl2NluTnBVYYh2K3NNCcWfcmmUB7nBcNBctiJeEZAixp3I1vQ9H88iHZ9MbHSdkuupQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrayify-stream/-/arrayify-stream-2.0.1.tgz",
+      "integrity": "sha512-z8fB6PtmnewQpFB53piS2d1KlUi3BPMICH2h7leCOUXpQcwvZ4GbHHSpdKoUrgLMR6b4Qan/uDe1St3Ao3yIHg=="
     },
     "asn1": {
       "version": "0.2.6",
@@ -17489,15 +16047,20 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
+    "async-lock": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
+      "integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ=="
+    },
     "asynciterator": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.8.0.tgz",
       "integrity": "sha512-bD34LqKHJnkB77MHjL3hOAUOcy9dbB+3lHvL+EiJpD3k2Nyq3i1dCk5adMisB2rwlrHVu/+XRhOdPZL9hzpsfw=="
     },
     "asyncjoin": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.1.1.tgz",
-      "integrity": "sha512-8IqFEIQ3HVec3dLQBvLRx/EFDOof8o+r4nCahRGqGE6WDPTXk7IBEaL6clPZ87DHku7u4yxHGzGWqMN08YwErg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.1.2.tgz",
+      "integrity": "sha512-zi6B+C3GgEu8qrmFn3gDd58cbGNaNFW3s8DJmCxUOjQwqWZcQO6dEoZBWl56+QGQyX0da0FRX1fsAyYB9LmwJA==",
       "requires": {
         "asynciterator": "^3.6.0"
       }
@@ -17511,6 +16074,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "await-notify": {
       "version": "1.0.1",
@@ -17538,9 +16106,9 @@
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
     },
     "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -17584,10 +16152,20 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+    },
+    "bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
     },
     "body-parser": {
       "version": "1.20.1",
@@ -17627,7 +16205,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -17671,15 +16248,15 @@
       "integrity": "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg=="
     },
     "browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.21.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
       "peer": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001503",
+        "electron-to-chromium": "^1.4.431",
+        "node-releases": "^2.0.12",
+        "update-browserslist-db": "^1.0.11"
       }
     },
     "buffer": {
@@ -17717,10 +16294,24 @@
         "unset-value": "^1.0.0"
       }
     },
+    "cache-content-type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
+      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
+      "requires": {
+        "mime-types": "^2.1.18",
+        "ylru": "^1.2.0"
+      }
+    },
+    "cacheable-lookup": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz",
+      "integrity": "sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww=="
+    },
     "cacheable-request": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "requires": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -17747,9 +16338,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001439",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
-      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
+      "version": "1.0.30001512",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz",
+      "integrity": "sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==",
       "peer": true
     },
     "canonicalize": {
@@ -17878,19 +16469,29 @@
       }
     },
     "clownface-shacl-path": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/clownface-shacl-path/-/clownface-shacl-path-1.4.0.tgz",
-      "integrity": "sha512-87AFtxaJzIYxC+cJ7AsayDRkiubxFrBhSWpxF60d8EFOJU3I8T4c/DpaYjurbebZuxOslHuBPtfZSDJqERLm5g==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/clownface-shacl-path/-/clownface-shacl-path-1.5.1.tgz",
+      "integrity": "sha512-p7mNA/rtl0x6zfIdbbqcwrrgH53dkq3yCAepRH0LMT6ZJTR7zQZ7ggM2ZKcXZWSvH+v2j6MjJjrp8PQpFNX+TA==",
       "requires": {
         "@rdf-esm/term-set": "^0.5.0",
         "@tpluscode/rdf-ns-builders": "^2.0.0",
         "@tpluscode/rdf-string": "^0.2.26"
       }
     },
+    "cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ=="
+    },
     "code-block-writer": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
-      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-12.0.0.tgz",
+      "integrity": "sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==",
       "peer": true
     },
     "collection-visit": {
@@ -17966,88 +16567,54 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "componentsjs": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-4.5.0.tgz",
-      "integrity": "sha512-0F473HDUFfizVXZH1KBP4jmZRBAqYdVdpGhaNmHFmla/AB76B8NN7hQk7YDGaKkESl9zYqQ6kF3i8UgJBQ+rtg==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.4.2.tgz",
+      "integrity": "sha512-qIeXLozDkvubl6qtiovWsIBRqUP80w1ImTbilB6QE3OQgaEExI8pYZ9MkZ10QDFtdoKUryztlqp0AWs49t4puA==",
       "requires": {
         "@rdfjs/types": "*",
         "@types/minimist": "^1.2.0",
-        "@types/node": "^14.14.7",
+        "@types/node": "^18.0.0",
         "@types/semver": "^7.3.4",
         "jsonld-context-parser": "^2.1.1",
         "minimist": "^1.2.0",
         "rdf-data-factory": "^1.1.0",
-        "rdf-object": "^1.11.1",
-        "rdf-parse": "^1.9.1",
+        "rdf-object": "^1.14.0",
+        "rdf-parse": "^2.0.0",
         "rdf-quad": "^1.5.0",
+        "rdf-string": "^1.6.0",
         "rdf-terms": "^1.7.0",
         "semver": "^7.3.2",
         "winston": "^3.3.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.18.34",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
-          "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA=="
-        }
       }
     },
     "componentsjs-generator": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/componentsjs-generator/-/componentsjs-generator-2.6.1.tgz",
-      "integrity": "sha512-WA8UNWbBbTmJmC5IxP/N+TJz/XBPfpdzlnzRB5fS2vOmZbwul54/kTxl2V+jjEh/k7Nyh8oKFd/4kE9ZRFSChA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/componentsjs-generator/-/componentsjs-generator-3.1.2.tgz",
+      "integrity": "sha512-0xYgpeH557mFNhwH0LornS5gNlQWrgvXACgvtLzMqDexA5HUY1YcDpTH4nRkfiAuF7Bw8bPDMFyru36lwsKhYA==",
       "requires": {
         "@types/lru-cache": "^5.1.0",
         "@types/semver": "^7.3.4",
-        "@typescript-eslint/typescript-estree": "^4.6.1",
+        "@typescript-eslint/typescript-estree": "^5.11.0",
         "comment-parser": "^0.7.6",
-        "componentsjs": "^4.4.0",
-        "jsonld-context-parser": "^2.0.2",
+        "componentsjs": "^5.0.1",
+        "jsonld-context-parser": "^2.1.5",
         "lru-cache": "^6.0.0",
         "minimist": "^1.2.5",
+        "rdf-object": "^1.13.1",
         "semver": "^7.3.2"
       },
       "dependencies": {
-        "@typescript-eslint/types": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-          "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ=="
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-          "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
-          "requires": {
-            "@typescript-eslint/types": "4.33.0",
-            "@typescript-eslint/visitor-keys": "4.33.0",
-            "debug": "^4.3.1",
-            "globby": "^11.0.3",
-            "is-glob": "^4.0.1",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-          "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
-          "requires": {
-            "@typescript-eslint/types": "4.33.0",
-            "eslint-visitor-keys": "^2.0.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+        "@types/lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
         }
       }
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -18071,6 +16638,15 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "cookies": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
+      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
+      "requires": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      }
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -18156,15 +16732,30 @@
         "ms": "2.1.2"
       }
     },
-    "decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
-    },
     "decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
       "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
+    },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "requires": {
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw=="
     },
     "deep-is": {
       "version": "0.1.4",
@@ -18172,10 +16763,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
+    },
     "define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
       "requires": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -18194,6 +16790,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
     },
     "depd": {
       "version": "2.0.0",
@@ -18229,20 +16835,13 @@
       }
     },
     "dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
-        }
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
       }
     },
     "domelementtype": {
@@ -18251,21 +16850,21 @@
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
     },
     "domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "requires": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       }
     },
     "domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
       "requires": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
       }
     },
     "dotenv": {
@@ -18287,10 +16886,18 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
+    "ejs": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "requires": {
+        "jake": "^10.8.5"
+      }
+    },
     "electron-to-chromium": {
-      "version": "1.4.284",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+      "version": "1.4.449",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.449.tgz",
+      "integrity": "sha512-TxLRpRUj/107ATefeP8VIUWNOv90xJxZZbCW/eIbSZQiuiFANCx2b7u+GbVc9X4gU+xnbvypNMYVM/WArE1DNQ==",
       "peer": true
     },
     "emoji-regex": {
@@ -18332,9 +16939,9 @@
       }
     },
     "entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "errno": {
       "version": "0.1.8",
@@ -18345,42 +16952,61 @@
       }
     },
     "es-abstract": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "requires": {
+        "array-buffer-byte-length": "^1.0.0",
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
+        "string.prototype.trim": "^1.2.7",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
-        "unbox-primitive": "^1.0.2"
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
       }
     },
     "es-module-lexer": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
+      "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
       "peer": true
+    },
+    "es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "requires": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "es-to-primitive": {
       "version": "1.2.1",
@@ -18585,8 +17211,7 @@
     "eslint-visitor-keys": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
     },
     "esm": {
       "version": "3.2.25",
@@ -18991,9 +17616,9 @@
       "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow=="
     },
     "fetch-sparql-endpoint": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-2.4.1.tgz",
-      "integrity": "sha512-4tDjPaRM3NH7CZ7ovLpFpyGQMtOH3L6LO/mbGT8ekHKvZyuXIkrykPTDmb0aEM13Wh1X1SzmQC22yqD8ORKe3w==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-3.3.3.tgz",
+      "integrity": "sha512-5ZNesFhFMcsEiSaCyg36L5VU7YP7xMJogc5i0n00nFNFZzrfGJ4Cm8LGrzXI6eySkb7QmaRyNWJGk5btAOjniA==",
       "requires": {
         "@rdfjs/types": "*",
         "@types/readable-stream": "^2.3.11",
@@ -19006,8 +17631,8 @@
         "rdf-string": "^1.6.0",
         "readable-web-to-node-stream": "^3.0.2",
         "sparqljs": "^3.1.2",
-        "sparqljson-parse": "^1.7.0",
-        "sparqlxml-parse": "^1.5.0",
+        "sparqljson-parse": "^2.2.0",
+        "sparqlxml-parse": "^2.1.1",
         "stream-to-string": "^1.1.0"
       }
     },
@@ -19018,6 +17643,32 @@
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
+      }
+    },
+    "filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "requires": {
+        "minimatch": "^5.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "fill-range": {
@@ -19110,6 +17761,14 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -19164,6 +17823,12 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -19191,12 +17856,13 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       }
     },
@@ -19268,6 +17934,14 @@
         "type-fest": "^0.20.2"
       }
     },
+    "globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -19289,10 +17963,35 @@
         "get-intrinsic": "^1.1.3"
       }
     },
+    "got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "requires": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "dependencies": {
+        "cacheable-lookup": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+          "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+        }
+      }
+    },
     "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -19305,62 +18004,35 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
       "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
     },
-    "graphql-ld": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/graphql-ld/-/graphql-ld-1.4.1.tgz",
-      "integrity": "sha512-oJ8o/1DdAbM+oNE9FBnc0bbWgzvImnl/o2fty2NzA4nyj4T6HNbAkr1CcUL9OieSZPEAW7QcU7W66OVHkxDwVw==",
-      "requires": {
-        "@rdfjs/types": "*",
-        "graphql-to-sparql": "^2.4.0",
-        "jsonld-context-parser": "^2.1.0",
-        "sparqlalgebrajs": "^3.0.2",
-        "sparqljson-to-tree": "^2.1.0"
-      },
-      "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
-        }
-      }
-    },
     "graphql-to-sparql": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-2.4.0.tgz",
-      "integrity": "sha512-AwfWSV8NUe5aY2QR+NzUUxImbe8GrUR12PvYBHq6r62aj66667yLdI5xOPsVGcS0DsQJN8+9CXC+vhkjc8mR9Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-3.0.1.tgz",
+      "integrity": "sha512-A+RwB99o66CUj+XuqtP/u3P7fGS/qF6P+/jhNl1BE/JZ2SCnkrODvV0LADuJeCDmPh45fDhq+GTDVoN1ZQHYFw==",
       "requires": {
         "@rdfjs/types": "*",
-        "graphql": "^15.0.0",
+        "graphql": "^15.5.2",
         "jsonld-context-parser": "^2.0.2",
         "minimist": "^1.2.0",
         "rdf-data-factory": "^1.1.0",
-        "sparqlalgebrajs": "^3.0.2"
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -19403,6 +18075,11 @@
       "requires": {
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
     },
     "has-symbols": {
       "version": "1.0.3",
@@ -19456,20 +18133,53 @@
       }
     },
     "htmlparser2": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+      "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
       "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.2",
-        "domutils": "^2.8.0",
-        "entities": "^3.0.1"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "requires": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
+        },
+        "http-errors": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.1"
+          }
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
+        }
       }
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-errors": {
       "version": "2.0.0",
@@ -19498,6 +18208,15 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "requires": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -19517,9 +18236,9 @@
       "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA=="
     },
     "immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -19553,13 +18272,29 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "requires": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "requires": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
       }
     },
     "ipaddr.js": {
@@ -19573,6 +18308,16 @@
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "requires": {
         "kind-of": "^6.0.0"
+      }
+    },
+    "is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
       }
     },
     "is-arrayish": {
@@ -19650,6 +18395,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-glob": {
       "version": "4.0.3",
@@ -19742,6 +18495,18 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -19771,6 +18536,11 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "iso8601-duration": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/iso8601-duration/-/iso8601-duration-2.1.1.tgz",
+      "integrity": "sha512-VGGpW30/R57FpG1J7RqqKBAaK7lIiudlZkQ5tRoO9hNlKYQNnhs60DQpXlPFBmp6I+kJ61PHkI3f/T7cR4wfbw=="
+    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -19780,6 +18550,62 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+    },
+    "jake": {
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
+      "requires": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "jest-worker": {
       "version": "27.5.1",
@@ -19810,9 +18636,9 @@
       }
     },
     "jose": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.1.tgz",
-      "integrity": "sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q=="
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+      "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g=="
     },
     "js-priority-queue": {
       "version": "0.1.5",
@@ -19838,6 +18664,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="
     },
     "json-buffer": {
       "version": "3.0.1",
@@ -19872,9 +18703,9 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -19900,9 +18731,9 @@
       }
     },
     "jsonld-context-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.2.2.tgz",
-      "integrity": "sha512-3VWIg/4NCMTXP6NsI6O93spFTd4qIOucKEmD8I+Exhxk9ZUVrnkLp2G4f0toR5jVleZkiiB9YGPS+yT1wwMqnQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.3.0.tgz",
+      "integrity": "sha512-c6w2GE57O26eWFjcPX6k6G86ootsIfpuVwhZKjCll0bVoDGBxr1P4OuU+yvgfnh1GJhAGErolfC7W1BklLjWMg==",
       "requires": {
         "@types/http-link-header": "^1.0.1",
         "@types/node": "^18.0.0",
@@ -19913,40 +18744,32 @@
       }
     },
     "jsonld-streaming-parser": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.4.3.tgz",
-      "integrity": "sha512-ysuevJ+l8+Y4W3J/yQW3pa9VCBNDHo2tZkKmPAnfhfsmFMyxuueAeXMmTbpJZdrpagzeeDVr3A8EZVuHliQJ9A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.2.0.tgz",
+      "integrity": "sha512-lJR1SCT364PGpFrOQaY+ZQ7qDWqqiT3IMK+AvZ83fo0LvltFn8/UyXvIFc3RO7YcaEjLahAF0otCi8vOq21NtQ==",
       "requires": {
+        "@bergos/jsonparse": "^1.4.0",
         "@rdfjs/types": "*",
         "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
         "canonicalize": "^1.0.1",
         "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.1.3",
-        "jsonparse": "^1.3.1",
-        "rdf-data-factory": "^1.1.0"
+        "jsonld-context-parser": "^2.3.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
       }
     },
     "jsonld-streaming-serializer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-1.3.0.tgz",
-      "integrity": "sha512-QGflpxpwmr659ExvAQ5TFAY9BmJQiL/yF/MDRrP5oVWHcBBLhbPjUqDv//y2OvJxUY3UQYMXulTwzmYb1ttv2Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-2.1.0.tgz",
+      "integrity": "sha512-COHdLoeMTnrqHMoFhN3PoAwqnrKrpPC7/ACb0WbELYvt+HSOIFN3v4IJP7fOtLNQ4GeaeYkvbeWJ7Jo4EjxMDw==",
       "requires": {
         "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.0.0"
-      }
-    },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
-    },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "jsonld-context-parser": "^2.0.0",
+        "readable-stream": "^4.0.0"
       }
     },
     "jsprim": {
@@ -19958,6 +18781,14 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
+      }
+    },
+    "keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "requires": {
+        "tsscmp": "1.0.6"
       }
     },
     "keyv": {
@@ -19972,6 +18803,76 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
+    "koa": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.14.2.tgz",
+      "integrity": "sha512-VFI2bpJaodz6P7x2uyLiX6RLYpZmOJqNmoCst/Yyd7hQlszyPwG/I9CQJ63nOtKSxpt5M7NH67V6nJL2BwCl7g==",
+      "requires": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.8.0",
+        "debug": "^4.3.2",
+        "delegates": "^1.0.0",
+        "depd": "^2.0.0",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^2.0.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.1"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+              "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
+            }
+          }
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
+        }
+      }
+    },
+    "koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
+    },
+    "koa-convert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
+      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
+      "requires": {
+        "co": "^4.6.0",
+        "koa-compose": "^4.1.0"
+      }
     },
     "kuler": {
       "version": "2.0.0",
@@ -20047,11 +18948,26 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.orderby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.orderby/-/lodash.orderby-4.6.0.tgz",
+      "integrity": "sha512-T0rZxKmghOOf5YPnn8EY5iLYeWCpZq8G41FfqoVHH5QDTAFaghJRmAdLiadEDq+ztgM2q5PjA+Z1fOwGrLgmtg=="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -20062,11 +18978,12 @@
       }
     },
     "logform": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.2.tgz",
-      "integrity": "sha512-W4c9himeAwXEdZ05dQNerhFz2XG80P9Oj0loPUMV23VC2it0orMHQhJm4hdnnor3rd1HsGf6a2lPwBM1zeXHGw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.5.1.tgz",
+      "integrity": "sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==",
       "requires": {
         "@colors/colors": "1.5.0",
+        "@types/triple-beam": "^1.3.2",
         "fecha": "^4.2.0",
         "ms": "^2.1.1",
         "safe-stable-stringify": "^2.3.1",
@@ -20124,6 +19041,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -20139,9 +19061,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -20189,30 +19111,26 @@
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
     },
     "microdata-rdf-streaming-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-1.2.0.tgz",
-      "integrity": "sha512-cMLNLEcS0mPaiA9iwq6BnsQK9sx2uBwjpRZIEvMRBNJpbvV58f8AFtPeYzNFh3OPyX9B49NYJ77bB0jNAUCurw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-2.0.1.tgz",
+      "integrity": "sha512-oEEYP3OwPGOtoE4eIyJvX1eJXI7VkGR4gKYqpEufaRXc2ele/Tkid/KMU3Los13wGrOq6woSxLEGOYSHzpRvwA==",
       "requires": {
         "@rdfjs/types": "*",
-        "htmlparser2": "^6.0.0",
+        "htmlparser2": "^8.0.0",
         "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.1.0",
         "relative-to-absolute-iri": "^1.0.2"
       },
       "dependencies": {
-        "entities": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
-        },
         "htmlparser2": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+          "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
           "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^4.0.0",
-            "domutils": "^2.5.2",
-            "entities": "^2.0.0"
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3",
+            "domutils": "^3.0.1",
+            "entities": "^4.4.0"
           }
         }
       }
@@ -20269,15 +19187,14 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -20307,26 +19224,18 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "n3": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.3.tgz",
-      "integrity": "sha512-9caLSZuMW1kdlPxEN4ka6E4E8a5QKoZ2emxpW+zHMofI+Bo92nJhN//wNub15S5T9I4c6saEqdGEu+YXJqMZVA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.17.0.tgz",
+      "integrity": "sha512-dYdkyUM4tMWHSEf9xMDPiBjOJc+rcjZHtN5cJJGcvAwOWTjE9u1i28sDFWALTwyROvsuUKuLohrz7VFaJbhiDw==",
       "requires": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10"
-          }
-        }
       }
+    },
+    "nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -20371,8 +19280,7 @@
     "neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "peer": true
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "next-tick": {
       "version": "1.1.0",
@@ -20388,10 +19296,15 @@
       }
     },
     "node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
       "peer": true
+    },
+    "nodemailer": {
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.3.tgz",
+      "integrity": "sha512-fy9v3NgTzBngrMFkDsKEj0r02U7jm6XfC3b52eoNV+GCrGj+s8pt5OqhiJdWKuw51zCTdiNR/IUD1z33LIIGpg=="
     },
     "normalize-url": {
       "version": "6.1.0",
@@ -20475,9 +19388,9 @@
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -20521,6 +19434,29 @@
         "isobject": "^3.0.1"
       }
     },
+    "oidc-provider": {
+      "version": "7.10.6",
+      "resolved": "https://registry.npmjs.org/oidc-provider/-/oidc-provider-7.10.6.tgz",
+      "integrity": "sha512-7fbnormUyTLP34dmR5WXoJtTWtfj6MsFNzIMKVRKv21e18NIXggn14EBUFC5rrMMtmeExb03+lJI/v+opD+0oQ==",
+      "requires": {
+        "@koa/cors": "^3.1.0",
+        "cacheable-lookup": "^6.0.1",
+        "debug": "^4.3.2",
+        "ejs": "^3.1.6",
+        "got": "^11.8.2",
+        "jose": "^4.1.4",
+        "jsesc": "^3.0.2",
+        "koa": "^2.13.3",
+        "koa-compose": "^4.1.0",
+        "nanoid": "^3.1.28",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.1",
+        "paseto2": "npm:paseto@^2.1.3",
+        "paseto3": "npm:paseto@^3.0.0",
+        "quick-lru": "^5.1.1",
+        "raw-body": "^2.4.1"
+      }
+    },
     "oidc-token-hash": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
@@ -20550,6 +19486,11 @@
         "fn.name": "1.x.x"
       }
     },
+    "only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ=="
+    },
     "openid-client": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.3.1.tgz",
@@ -20574,6 +19515,11 @@
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
       }
+    },
+    "p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
     },
     "p-limit": {
       "version": "3.1.0",
@@ -20601,9 +19547,9 @@
       }
     },
     "parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha512-Z0gpfHmwCIKDr5rRzjypL+p93aHVWO7e+0rFcUl9E3sC67njjs+xHFenuboSXZGlvYtmQqRzRaE3iFpTUnLmFQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
       "requires": {
         "xtend": "~4.0.1"
       }
@@ -20617,6 +19563,17 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw=="
+    },
+    "paseto2": {
+      "version": "npm:paseto@2.1.3",
+      "resolved": "https://registry.npmjs.org/paseto/-/paseto-2.1.3.tgz",
+      "integrity": "sha512-BNkbvr0ZFDbh3oV13QzT5jXIu8xpFc9r0o5mvWBhDU1GBkVt1IzHK1N6dcYmN7XImrUmPQ0HCUXmoe2WPo8xsg=="
+    },
+    "paseto3": {
+      "version": "npm:paseto@3.1.4",
+      "resolved": "https://registry.npmjs.org/paseto/-/paseto-3.1.4.tgz",
+      "integrity": "sha512-BifaKKu+MS9b/vTgFMC6Q8uLUMqw8VtYgl4qODJWb6Jqt+dTKn8XH9EftJZx+6wxF4ELBbKdH33DZa4inMYVcg==",
+      "optional": true
     },
     "path-browserify": {
       "version": "1.0.1",
@@ -20701,6 +19658,16 @@
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
       "integrity": "sha512-7rrONfyLkDEc7OJ5QBkqa4KI4EBhCd340xRuIUPGCfu13znS+vx+VDdrT9ODAJHlXm7w4lbxN3DRjyv58EuzDg=="
     },
+    "proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -20747,6 +19714,11 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -20780,154 +19752,48 @@
       }
     },
     "rdf-data-factory": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.1.tgz",
-      "integrity": "sha512-0HoLx7lbBlNd2YTmNKin0txgiYmAV56eVU823at8cG2+iD0Ia5kcRNDpzZy6I/HCtFTymHvTfdhHTzm3ak3Jpw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
+      "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
       "requires": {
         "@rdfjs/types": "*"
       }
     },
     "rdf-dereference": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/rdf-dereference/-/rdf-dereference-1.9.0.tgz",
-      "integrity": "sha512-nRpESjNKoUugzqMyM/perJXZpKIR+Ac6yhkDzq+Zcjc9lQte5ptz+I7EQn0+2DbZwLvKlb/P/FXI+wTBMpGBAA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-dereference/-/rdf-dereference-2.1.0.tgz",
+      "integrity": "sha512-1ZUgruR9mkFC+sbn8qWTDVEL+NgU6MUS4Fp4c0ykZFPizopwvtBqr2Z8IJr579HGFY7HBZIfgljNXMqFls+PHQ==",
       "requires": {
-        "@comunica/actor-http-node-fetch": "~1.22.0",
-        "@comunica/actor-http-proxy": "~1.22.0",
-        "@comunica/actor-rdf-dereference-file": "~1.22.0",
-        "@comunica/actor-rdf-dereference-http-parse": "~1.22.0",
-        "@comunica/actor-rdf-parse-html": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-microdata": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-rdfa": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-script": "~1.22.0",
-        "@comunica/actor-rdf-parse-jsonld": "~1.22.0",
-        "@comunica/actor-rdf-parse-n3": "~1.22.0",
-        "@comunica/actor-rdf-parse-rdfxml": "~1.22.0",
-        "@comunica/actor-rdf-parse-xml-rdfa": "~1.22.0",
-        "@comunica/bus-http": "~1.22.0",
-        "@comunica/bus-init": "~1.22.0",
-        "@comunica/bus-rdf-dereference": "~1.22.0",
-        "@comunica/bus-rdf-parse": "~1.22.0",
-        "@comunica/bus-rdf-parse-html": "~1.22.0",
-        "@comunica/core": "~1.22.0",
-        "@comunica/mediator-combine-union": "~1.22.0",
-        "@comunica/mediator-number": "~1.22.0",
-        "@comunica/mediator-race": "~1.22.0",
+        "@comunica/actor-dereference-fallback": "^2.0.2",
+        "@comunica/actor-dereference-file": "^2.0.2",
+        "@comunica/actor-dereference-http": "^2.0.2",
+        "@comunica/actor-dereference-rdf-parse": "^2.6.0",
+        "@comunica/actor-http-fetch": "^2.0.1",
+        "@comunica/actor-http-proxy": "^2.0.1",
+        "@comunica/actor-rdf-parse-html": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-parse-n3": "^2.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
+        "@comunica/actor-rdf-parse-shaclc": "^2.6.0",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
+        "@comunica/bus-dereference": "^2.0.2",
+        "@comunica/bus-dereference-rdf": "^2.0.2",
+        "@comunica/bus-http": "^2.0.1",
+        "@comunica/bus-init": "^2.0.1",
+        "@comunica/bus-rdf-parse": "^2.0.1",
+        "@comunica/bus-rdf-parse-html": "^2.0.1",
+        "@comunica/config-query-sparql": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/mediator-combine-pipeline": "^2.0.1",
+        "@comunica/mediator-combine-union": "^2.0.1",
+        "@comunica/mediator-number": "^2.0.1",
+        "@comunica/mediator-race": "^2.0.1",
         "@rdfjs/types": "*",
         "rdf-string": "^1.6.0",
         "stream-to-string": "^1.2.0"
-      },
-      "dependencies": {
-        "@comunica/actor-http-node-fetch": {
-          "version": "1.22.3",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-http-node-fetch/-/actor-http-node-fetch-1.22.3.tgz",
-          "integrity": "sha512-e2J8g32QgwcbysOQkFDio757oaPLCGpSs7rRDoGq/daGS8l1m7Ugzhx7Vh3NHcCI3XXrymMOBzMT+ku5ddJbNg==",
-          "requires": {
-            "@comunica/context-entries": "^1.22.0",
-            "cross-fetch": "^3.0.5"
-          }
-        },
-        "@comunica/actor-http-proxy": {
-          "version": "1.22.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.22.1.tgz",
-          "integrity": "sha512-q8Dil+MnKeZWKNxLLDXan070TUP+8io7zwwCs5apvaU26ghojBU4OOJx1vL6CInUjZCzTeyCYVPsBbvykjLZ2w==",
-          "requires": {}
-        },
-        "@comunica/actor-rdf-dereference-http-parse": {
-          "version": "1.22.3",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.22.3.tgz",
-          "integrity": "sha512-OBtJTHA8OXAWF3+FJ7n0R1i8nGzxD2xK18mgMPu4JId9r9bUS4RMKCDWa8MIG6p9Hd7SleuS9bC48w5vm07yww==",
-          "requires": {
-            "cross-fetch": "^3.0.5",
-            "relative-to-absolute-iri": "^1.0.5",
-            "stream-to-string": "^1.2.0"
-          }
-        },
-        "@comunica/actor-rdf-parse-jsonld": {
-          "version": "1.22.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.22.1.tgz",
-          "integrity": "sha512-MFFhJ6eGyO40Be80zsFKAbRjkPXr80PvCqvVKsEstdv3u9C6GFV3nqZpCwvsVCz22IPQhW+rzb8ZyasmgHnurA==",
-          "requires": {
-            "@comunica/context-entries": "^1.22.0",
-            "@rdfjs/types": "*",
-            "jsonld-context-parser": "^2.1.2",
-            "jsonld-streaming-parser": "^2.4.0",
-            "stream-to-string": "^1.2.0"
-          }
-        },
-        "@comunica/actor-rdf-parse-n3": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.22.0.tgz",
-          "integrity": "sha512-qHrGfh5k/pZa4imy7m9gJ1kt9aW1uxXqLDKnLKvR2l0m09YiEx/YOYWr1Wtu1YtH/Yyc13OX4mo/OwaE5PfrHQ==",
-          "requires": {
-            "@types/n3": "^1.4.4",
-            "n3": "^1.6.3"
-          }
-        },
-        "@comunica/bus-http": {
-          "version": "1.22.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.22.1.tgz",
-          "integrity": "sha512-CZ0NDWZH0k0FOshuRQJzYr3Z+2ZM1vqr9ZepONuaoYDwyKaxl29xPs3hNfjSy6YawjEQP+elr/WDc3TxKIpu8g==",
-          "requires": {
-            "@comunica/context-entries": "^1.22.0",
-            "@types/readable-stream": "^2.3.11",
-            "is-stream": "^2.0.0",
-            "readable-web-to-node-stream": "^3.0.2",
-            "web-streams-node": "^0.4.0"
-          }
-        },
-        "@comunica/bus-init": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.22.0.tgz",
-          "integrity": "sha512-NIfEJLI8EYFdTWJB0PV/lxPagStPl+gUj3LtOnovcF1ZhC5rgcJSC/tq1r04n0TziY2KVangnLDsF4752LjD6g==",
-          "requires": {}
-        },
-        "@comunica/bus-rdf-dereference": {
-          "version": "1.22.2",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.22.2.tgz",
-          "integrity": "sha512-dtLEmCzlscpe8AqEver8H+7a7UzyOXslUQ00VE+igt/+oAQvJpRBCQ3yB6XkyjAV/+ApLrbAjpCRf3Gp2NWfgg==",
-          "requires": {
-            "@comunica/context-entries": "^1.22.0",
-            "@rdfjs/types": "*"
-          }
-        },
-        "@comunica/bus-rdf-parse": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.22.0.tgz",
-          "integrity": "sha512-ohZGlabX5K+dEmn+v4BzP+IZVyRc1ovWItHDLznnRqsHQr8W19WPG21lEFh5kk2MK4YnyQWmlUax1Yxrg7cbXg==",
-          "requires": {
-            "@comunica/actor-abstract-mediatyped": "^1.22.0",
-            "@rdfjs/types": "*"
-          }
-        },
-        "@comunica/core": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.22.0.tgz",
-          "integrity": "sha512-tgozygRFTd6t6l0YyvfVUWNC+KXWiTlBclkxtzFioQsplKvUSvg1TPjopRk8hhAvMaNRGMNBK2ZafNaqNTkI4w==",
-          "requires": {
-            "@comunica/context-entries": "^1.22.0",
-            "@comunica/types": "^1.22.0",
-            "immutable": "^3.8.2"
-          }
-        },
-        "@comunica/mediator-combine-union": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.22.0.tgz",
-          "integrity": "sha512-iUHmEGgWVmk02e80uB7w8xZ5vgTLpiqzrImvbokolJzWcVbobVCUkq8DUxzz3FJbNVRGipZUFrOqkRPAuAX6FA==",
-          "requires": {}
-        },
-        "@comunica/mediator-number": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.22.0.tgz",
-          "integrity": "sha512-KDPlJEvj0Lu+JygGXjnH8pf33k01lJ+wgzUlWK216jZJ1Px2lTlfc/COhSqi/e0y+k4ZSBcxx0gnjt2awMpbrQ==",
-          "requires": {}
-        },
-        "@comunica/mediator-race": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.22.0.tgz",
-          "integrity": "sha512-hIMaHyf9M4jOS0199OURSVgWFmzkyF2K2keuAb+iHoCH3UUcUnWjPOL1TrdkxvaUnrxmsBWR9SXbnqgMnhIsiQ==",
-          "requires": {}
-        }
       }
     },
     "rdf-ext": {
@@ -20942,10 +19808,15 @@
         "readable-stream": "^3.6.0"
       },
       "dependencies": {
-        "@rdfjs/to-ntriples": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz",
-          "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA=="
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         }
       }
     },
@@ -20983,9 +19854,9 @@
       "integrity": "sha512-1ocjoxovKc4+AyS4Tgtroay5R33yrtM2kQnAGvVaB0iGSRggukHxMJW0y8xTR7TwKZabS+7oMSQNMdbu/qTtCQ=="
     },
     "rdf-object": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.13.2.tgz",
-      "integrity": "sha512-DVLDCbxPOkhd/k43j9wcLU7CXe/gdldBBomMV3RyZ1G9E2zPa2FFNFijzMGgRGNY1OEyGmhBxw2eiJjUC7GVNw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.14.0.tgz",
+      "integrity": "sha512-/KSUWr7onDtL7d81kOpcUzJ2vHYOYJc2KU9WzBZRYydBhK0Sksh5Hg4VCQNaxUEvYEgdrrTuq9SLpOOCmag0rQ==",
       "requires": {
         "@rdfjs/types": "*",
         "jsonld-context-parser": "^2.0.2",
@@ -20995,107 +19866,34 @@
       }
     },
     "rdf-parse": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-1.9.1.tgz",
-      "integrity": "sha512-W6ouYE+ufmCNFmXD1iGs5gUZH75jZekh/I5qF8a4Sl37BUc9mY0Jz5A0CV1tiKKhx+I+HYfxyX9VjOljD8rzgQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.3.2.tgz",
+      "integrity": "sha512-TOeI7FKlyr/GupfGaXZvpMLzvByOrtwt4zHLMuuy3deNGse9QyhHsspVraZam491sIgBogdchzcUqkf2WXnAsg==",
       "requires": {
-        "@comunica/actor-http-native": "~1.22.0",
-        "@comunica/actor-rdf-parse-html": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-microdata": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-rdfa": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-script": "~1.22.0",
-        "@comunica/actor-rdf-parse-jsonld": "^1.22.0",
-        "@comunica/actor-rdf-parse-n3": "~1.22.0",
-        "@comunica/actor-rdf-parse-rdfxml": "~1.22.0",
-        "@comunica/actor-rdf-parse-xml-rdfa": "~1.22.0",
-        "@comunica/bus-http": "~1.22.0",
-        "@comunica/bus-init": "~1.22.0",
-        "@comunica/bus-rdf-parse": "~1.22.0",
-        "@comunica/bus-rdf-parse-html": "~1.22.0",
-        "@comunica/core": "~1.22.0",
-        "@comunica/mediator-combine-union": "~1.22.0",
-        "@comunica/mediator-number": "~1.22.0",
-        "@comunica/mediator-race": "~1.22.0",
+        "@comunica/actor-http-fetch": "^2.0.1",
+        "@comunica/actor-http-proxy": "^2.0.1",
+        "@comunica/actor-rdf-parse-html": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-parse-n3": "^2.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
+        "@comunica/actor-rdf-parse-shaclc": "^2.6.2",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
+        "@comunica/bus-http": "^2.0.1",
+        "@comunica/bus-init": "^2.0.1",
+        "@comunica/bus-rdf-parse": "^2.0.1",
+        "@comunica/bus-rdf-parse-html": "^2.0.1",
+        "@comunica/config-query-sparql": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/mediator-combine-pipeline": "^2.0.1",
+        "@comunica/mediator-combine-union": "^2.0.1",
+        "@comunica/mediator-number": "^2.0.1",
+        "@comunica/mediator-race": "^2.0.1",
         "@rdfjs/types": "*",
+        "readable-stream": "^4.3.0",
         "stream-to-string": "^1.2.0"
-      },
-      "dependencies": {
-        "@comunica/actor-rdf-parse-jsonld": {
-          "version": "1.22.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.22.1.tgz",
-          "integrity": "sha512-MFFhJ6eGyO40Be80zsFKAbRjkPXr80PvCqvVKsEstdv3u9C6GFV3nqZpCwvsVCz22IPQhW+rzb8ZyasmgHnurA==",
-          "requires": {
-            "@comunica/context-entries": "^1.22.0",
-            "@rdfjs/types": "*",
-            "jsonld-context-parser": "^2.1.2",
-            "jsonld-streaming-parser": "^2.4.0",
-            "stream-to-string": "^1.2.0"
-          }
-        },
-        "@comunica/actor-rdf-parse-n3": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.22.0.tgz",
-          "integrity": "sha512-qHrGfh5k/pZa4imy7m9gJ1kt9aW1uxXqLDKnLKvR2l0m09YiEx/YOYWr1Wtu1YtH/Yyc13OX4mo/OwaE5PfrHQ==",
-          "requires": {
-            "@types/n3": "^1.4.4",
-            "n3": "^1.6.3"
-          }
-        },
-        "@comunica/bus-http": {
-          "version": "1.22.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.22.1.tgz",
-          "integrity": "sha512-CZ0NDWZH0k0FOshuRQJzYr3Z+2ZM1vqr9ZepONuaoYDwyKaxl29xPs3hNfjSy6YawjEQP+elr/WDc3TxKIpu8g==",
-          "requires": {
-            "@comunica/context-entries": "^1.22.0",
-            "@types/readable-stream": "^2.3.11",
-            "is-stream": "^2.0.0",
-            "readable-web-to-node-stream": "^3.0.2",
-            "web-streams-node": "^0.4.0"
-          }
-        },
-        "@comunica/bus-init": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.22.0.tgz",
-          "integrity": "sha512-NIfEJLI8EYFdTWJB0PV/lxPagStPl+gUj3LtOnovcF1ZhC5rgcJSC/tq1r04n0TziY2KVangnLDsF4752LjD6g==",
-          "requires": {}
-        },
-        "@comunica/bus-rdf-parse": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.22.0.tgz",
-          "integrity": "sha512-ohZGlabX5K+dEmn+v4BzP+IZVyRc1ovWItHDLznnRqsHQr8W19WPG21lEFh5kk2MK4YnyQWmlUax1Yxrg7cbXg==",
-          "requires": {
-            "@comunica/actor-abstract-mediatyped": "^1.22.0",
-            "@rdfjs/types": "*"
-          }
-        },
-        "@comunica/core": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.22.0.tgz",
-          "integrity": "sha512-tgozygRFTd6t6l0YyvfVUWNC+KXWiTlBclkxtzFioQsplKvUSvg1TPjopRk8hhAvMaNRGMNBK2ZafNaqNTkI4w==",
-          "requires": {
-            "@comunica/context-entries": "^1.22.0",
-            "@comunica/types": "^1.22.0",
-            "immutable": "^3.8.2"
-          }
-        },
-        "@comunica/mediator-combine-union": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.22.0.tgz",
-          "integrity": "sha512-iUHmEGgWVmk02e80uB7w8xZ5vgTLpiqzrImvbokolJzWcVbobVCUkq8DUxzz3FJbNVRGipZUFrOqkRPAuAX6FA==",
-          "requires": {}
-        },
-        "@comunica/mediator-number": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.22.0.tgz",
-          "integrity": "sha512-KDPlJEvj0Lu+JygGXjnH8pf33k01lJ+wgzUlWK216jZJ1Px2lTlfc/COhSqi/e0y+k4ZSBcxx0gnjt2awMpbrQ==",
-          "requires": {}
-        },
-        "@comunica/mediator-race": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.22.0.tgz",
-          "integrity": "sha512-hIMaHyf9M4jOS0199OURSVgWFmzkyF2K2keuAb+iHoCH3UUcUnWjPOL1TrdkxvaUnrxmsBWR9SXbnqgMnhIsiQ==",
-          "requires": {}
-        }
       }
     },
     "rdf-quad": {
@@ -21109,12 +19907,13 @@
       }
     },
     "rdf-serialize": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rdf-serialize/-/rdf-serialize-2.0.1.tgz",
-      "integrity": "sha512-GjFSp0Nzh4wxs6lpmdTQQBpjKYl8Lt89dR6PYuLp/YkliByR9tf6c+v4O1srFlfeCZ1u6xMarP0V3/CTMPqy8g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rdf-serialize/-/rdf-serialize-2.2.2.tgz",
+      "integrity": "sha512-zzWQMMMmDzocuFLEOcdz8U5AxbdjBvknwFEHXCyw2lklcEjd2OtsvD5NgWQc+zbsWZKxewvDYEXuzhkNAHRv1g==",
       "requires": {
-        "@comunica/actor-rdf-serialize-jsonld": "^2.0.1",
-        "@comunica/actor-rdf-serialize-n3": "^2.0.1",
+        "@comunica/actor-rdf-serialize-jsonld": "^2.6.6",
+        "@comunica/actor-rdf-serialize-n3": "^2.6.6",
+        "@comunica/actor-rdf-serialize-shaclc": "^2.6.0",
         "@comunica/bus-init": "^2.0.1",
         "@comunica/bus-rdf-serialize": "^2.0.1",
         "@comunica/config-query-sparql": "^2.0.1",
@@ -21123,145 +19922,8 @@
         "@comunica/mediator-combine-union": "^2.0.1",
         "@comunica/mediator-race": "^2.0.1",
         "@rdfjs/types": "*",
-        "stream-to-string": "^1.2.0"
-      },
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.5.1.tgz",
-          "integrity": "sha512-Iz8j1XqXp/A7HJVDTtEtp7hV6nuNoIjjEUgiJUiBTM5OIx7sFbGfUd10VtHPSXB/3lHHcIo34BKNZkeurNo6BA==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1"
-          }
-        },
-        "@comunica/actor-rdf-serialize-jsonld": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.5.1.tgz",
-          "integrity": "sha512-QYyruMJBKYeIeTENMsBfCq3/fRUTlmMtOchRn0Hf8vWp+ZO5sx7EksvwA3hEJ0yzbHaNSOoi53I5CcJYNMG2yA==",
-          "requires": {
-            "@comunica/bus-rdf-serialize": "^2.5.1",
-            "@comunica/types": "^2.5.1",
-            "jsonld-streaming-serializer": "^2.0.1"
-          }
-        },
-        "@comunica/actor-rdf-serialize-n3": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.5.1.tgz",
-          "integrity": "sha512-llK3kiNtqrEBTL5z8GIDM/SjT9nv41Pugm+H/j+hTjNIVfSCHpaobUuQdft7TDVYeXu6/U18lXcz8n1bAspKfA==",
-          "requires": {
-            "@comunica/bus-rdf-serialize": "^2.5.1",
-            "@comunica/types": "^2.5.1",
-            "n3": "^1.16.3"
-          }
-        },
-        "@comunica/bus-init": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.5.1.tgz",
-          "integrity": "sha512-TDakSkGzM+3xkZ+xBCBmzWNagmDWUc+F6TPYOFO8goaT1+tVrPh9wPD5t2n1zkKMzG2dOVT4O8jxUfCyzmNwKA==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "readable-stream": "^4.2.0"
-          }
-        },
-        "@comunica/bus-rdf-serialize": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.5.1.tgz",
-          "integrity": "sha512-GMg3dkWrFSYzxsp8hDNSgpWKyInDQ78lmy9TqVUo+EIgvIDhMXZJqsJmQNf/frcMYlPqdr1CwGnRxp+Jf7li+g==",
-          "requires": {
-            "@comunica/actor-abstract-mediatyped": "^2.5.1",
-            "@comunica/core": "^2.5.1",
-            "@rdfjs/types": "*"
-          }
-        },
-        "@comunica/core": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.5.1.tgz",
-          "integrity": "sha512-dTenKE5bYswM/jBp0vtrrs2FuFUUYnVnWAa5b8vzxPiZQ+JA8RsXafLJq7Gk09FYr+739DDMoEwFL2dwUE5yDA==",
-          "requires": {
-            "@comunica/types": "^2.5.1",
-            "immutable": "^4.1.0"
-          }
-        },
-        "@comunica/mediator-combine-pipeline": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.5.1.tgz",
-          "integrity": "sha512-vsi6YA7NGPQoNSPtKHWUbsDK+678w0BdE9DEzLWOa2pqiWoeT4SuJV4szHQNVuJjzi6j6VTXuR58mZL7XqreTw==",
-          "requires": {
-            "@comunica/core": "^2.5.1",
-            "@comunica/types": "^2.5.1"
-          }
-        },
-        "@comunica/mediator-combine-union": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.5.1.tgz",
-          "integrity": "sha512-vpbQn3xtoX+F00xv+AKbn+qUe66rIiycbiZoE/s/qtlmUbVKLItEMMuToDGRdcdC9mtPiieIrgremXd/RVdHTw==",
-          "requires": {
-            "@comunica/core": "^2.5.1"
-          }
-        },
-        "@comunica/mediator-race": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.5.1.tgz",
-          "integrity": "sha512-VuHHZSDagK9k85NBTEvbbhkb/Xd9zgt9jBlYIVRarushJ8ihqfs8dXQ2Hs0gdOTyrCMFiQIimbN1h58QcmmKyg==",
-          "requires": {
-            "@comunica/core": "^2.5.1"
-          }
-        },
-        "@comunica/types": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.5.1.tgz",
-          "integrity": "sha512-bo/C3s1eH1yrfdSB5tVYPTRgeI2kB7J2fQuAjCWndyk/RVYHew3ztIqOa7wlhgZ7aVw+X+TTCLRjNve2l1TMhg==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/yargs": "^17.0.13",
-            "asynciterator": "^3.8.0",
-            "sparqlalgebrajs": "^4.0.5"
-          }
-        },
-        "immutable": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
-        },
-        "jsonld-streaming-serializer": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-2.1.0.tgz",
-          "integrity": "sha512-COHdLoeMTnrqHMoFhN3PoAwqnrKrpPC7/ACb0WbELYvt+HSOIFN3v4IJP7fOtLNQ4GeaeYkvbeWJ7Jo4EjxMDw==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/readable-stream": "^2.3.13",
-            "buffer": "^6.0.3",
-            "jsonld-context-parser": "^2.0.0",
-            "readable-stream": "^4.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10"
-          }
-        },
-        "sparqlalgebrajs": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz",
-          "integrity": "sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.3",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.6",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.6.1"
-          }
-        }
+        "readable-stream": "^4.3.0",
+        "stream-to-string": "^1.1.0"
       }
     },
     "rdf-store-stream": {
@@ -21273,10 +19935,36 @@
         "n3": "^1.11.1"
       }
     },
+    "rdf-stores": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-stores/-/rdf-stores-1.0.0.tgz",
+      "integrity": "sha512-wqp7M5409rbhpWQE0C1vyVysbz++aD2vEkZ6yueSxhDtyLvznS41R3cKiuUpm3ikc/yTpaCZwPo4iyKEaAwBIg==",
+      "requires": {
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.2",
+        "rdf-terms": "^1.9.1"
+      }
+    },
+    "rdf-streaming-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-streaming-store/-/rdf-streaming-store-1.1.0.tgz",
+      "integrity": "sha512-C/5NTKGpKrNJ5VUo42DtGFsXYDlP3rx/u4C6gEBuSn+6eVFahjFdUDgNGcPtVyhCQkctRCj3GT1lX9UeyoXWtw==",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/n3": "^1.10.4",
+        "@types/readable-stream": "^2.3.15",
+        "n3": "^1.16.3",
+        "rdf-string": "^1.6.2",
+        "rdf-terms": "^1.9.1",
+        "readable-stream": "^4.3.0"
+      }
+    },
     "rdf-string": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.2.tgz",
-      "integrity": "sha512-tr0aStKYRmT6ShmGsA4HikIn6O3ZkCBSLWsRbeKhlPVPZodl0QNuws6HuJdD1rUyo9+MNiDw+3wvFSUz6Iwv/g==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
+      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
       "requires": {
         "@rdfjs/types": "*",
         "rdf-data-factory": "^1.1.0"
@@ -21292,63 +19980,95 @@
       }
     },
     "rdf-terms": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.9.1.tgz",
-      "integrity": "sha512-GrE8CbQSvuVEFRCywMu6VOgV1AFE6X+nFYcAhEc5pwYKI13bUvz4voiVufQiy3V8rzQKu21Sgl+dS2qcJavy7w==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
+      "integrity": "sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==",
       "requires": {
         "@rdfjs/types": "*",
         "rdf-data-factory": "^1.1.0",
         "rdf-string": "^1.6.0"
       }
     },
+    "rdf-validate-datatype": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/rdf-validate-datatype/-/rdf-validate-datatype-0.1.5.tgz",
+      "integrity": "sha512-gU+cD+AT1LpFwbemuEmTDjwLyFwJDiw21XHyIofKhFnEpXODjShBuxhgDGnZqW3qIEwu/vECjOecuD60e5ngiQ==",
+      "requires": {
+        "@rdfjs/namespace": "^1.1.0",
+        "@rdfjs/to-ntriples": "^2.0.0"
+      },
+      "dependencies": {
+        "@rdfjs/to-ntriples": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
+          "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q=="
+        }
+      }
+    },
+    "rdf-validate-shacl": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/rdf-validate-shacl/-/rdf-validate-shacl-0.4.5.tgz",
+      "integrity": "sha512-tGYnssuPzmsPua1dju4hEtGkT1zouvwzVTNrFhNiqj2aZFO5pQ7lvLd9Cv9H9vKAlpIdC/x0zL6btxG3PCss0w==",
+      "requires": {
+        "@rdfjs/dataset": "^1.1.1",
+        "@rdfjs/namespace": "^1.0.0",
+        "@rdfjs/term-set": "^1.1.0",
+        "clownface": "^1.4.0",
+        "debug": "^4.3.2",
+        "rdf-literal": "^1.3.0",
+        "rdf-validate-datatype": "^0.1.5"
+      }
+    },
     "rdfa-streaming-parser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-1.5.0.tgz",
-      "integrity": "sha512-A+Kl0vbRQKK3SqgWdCiR48Hi75LK6z6glPdGcbLXMw6qMRcLeIKe4p6yFkPXpbwtegmOa94uaxeLs5HMdo66AQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-2.0.1.tgz",
+      "integrity": "sha512-7Yyaj030LO7iQ38Wh/RNLVeYrVFJeyx3dpCK7C1nvX55eIN/gE4HWfbg4BYI9X7Bd+eUIUMVeiKYLmYjV6apow==",
       "requires": {
         "@rdfjs/types": "*",
-        "htmlparser2": "^6.0.0",
+        "htmlparser2": "^8.0.0",
         "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0",
         "relative-to-absolute-iri": "^1.0.2"
       },
       "dependencies": {
-        "entities": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
-        },
         "htmlparser2": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+          "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
           "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^4.0.0",
-            "domutils": "^2.5.2",
-            "entities": "^2.0.0"
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3",
+            "domutils": "^3.0.1",
+            "entities": "^4.4.0"
           }
         }
       }
     },
     "rdfxml-streaming-parser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.5.0.tgz",
-      "integrity": "sha512-pnt+7NgeqCMd2/rub+dqxzYJhZwJjBNU2BRwyYdCTmRZu2fr795jCPJB6Io5pjPzAt29ASqy+ODBSRMDKoKGbQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.2.3.tgz",
+      "integrity": "sha512-HoH8urnga+YQ5sDY9ufRb0wg6FvwR284sSXpZ+fJE5X5Oej6dfzkFer81uBNZzyNmzJR1TpMYMznyXEjPMLhCA==",
       "requires": {
         "@rdfjs/types": "*",
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
         "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0",
         "relative-to-absolute-iri": "^1.0.0",
-        "sax": "^1.2.4"
+        "validate-iri": "^1.0.0"
       }
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
       "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       }
     },
     "readable-stream-node-to-web": {
@@ -21362,6 +20082,18 @@
       "integrity": "sha512-G+0kz01xJM/uTuItKcqC73cifW8S6CZ7tp77NLN87lE5mrSU+GC8geoSAlfmp0NocmXckQ7W8s8ns73HYsIA3w==",
       "requires": {
         "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "readable-web-to-node-stream": {
@@ -21370,6 +20102,31 @@
       "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
       "requires": {
         "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "requires": {
+        "redis-errors": "^1.0.0"
       }
     },
     "regex-not": {
@@ -21382,13 +20139,13 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
       }
     },
     "regexpp": {
@@ -21456,6 +20213,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
+    "resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -21479,6 +20241,11 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -21532,56 +20299,19 @@
       }
     },
     "safe-stable-stringify": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
-      "integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA=="
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "sax-stream": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax-stream/-/sax-stream-1.3.0.tgz",
-      "integrity": "sha512-tcfsAAICAkyNNe4uiKtKmLKxx3C7qPAej13UUoN+7OLYq/P5kHGahZtJhhMVM3fIMndA6TlYHWFlFEzFkv1VGg==",
-      "requires": {
-        "debug": "~2",
-        "sax": "~1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        }
-      }
-    },
-    "saxes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "requires": {
-        "xmlchars": "^2.2.0"
-      }
-    },
     "schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "peer": true,
       "requires": {
         "@types/json-schema": "^7.0.8",
@@ -21694,6 +20424,25 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "shaclc-parse": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/shaclc-parse/-/shaclc-parse-1.4.0.tgz",
+      "integrity": "sha512-zyxjIYQH2ghg/wtMvOp+4Nr6aK8j9bqFiVT3w47K8WHPYN+S3Zgnh2ybT+dGgMwo9KjiOoywxhjC7d8Z6GCmfA==",
+      "requires": {
+        "@rdfjs/types": "^1.1.0",
+        "n3": "^1.16.3"
+      }
+    },
+    "shaclc-write": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/shaclc-write/-/shaclc-write-1.4.2.tgz",
+      "integrity": "sha512-aejD8fNgTfTINInjlwW7oz4GbmIJmDFJu4Tc3WVhmMH2QV24F+Ey/I/obMP/cQu/LwcfX7O2eu7bI9RUFeDMWw==",
+      "requires": {
+        "@jeswr/prefixcc": "^1.2.1",
+        "n3": "^1.16.3",
+        "rdf-string-ttl": "^1.3.2"
+      }
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -21718,6 +20467,11 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -21941,51 +20695,46 @@
       "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
     },
     "sparqlalgebrajs": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
-      "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.2.0.tgz",
+      "integrity": "sha512-tdlJdrvgQqgx9zubcl9iiyCxMOp4qRT2fs1Sne8X35QTm1Pj2ulB+gGEHunJJnw5FW7Uhtmw7J3px0sCmgJSbw==",
       "requires": {
+        "@rdfjs/types": "*",
+        "@types/sparqljs": "^3.1.3",
         "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.0.4",
-        "rdf-isomorphic": "^1.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqljs": "^3.3.0"
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-isomorphic": "^1.3.0",
+        "rdf-string": "^1.6.0",
+        "rdf-terms": "^1.10.0",
+        "sparqljs": "^3.7.1"
       }
     },
     "sparqlee": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-1.10.0.tgz",
-      "integrity": "sha512-rKuyXIIyEsRsACZC86yrN0m/rUhKZQl6HfqeIqAC+5WXE08PB/tGQ9RPxiwo+P6u6QEk2Sd/h6Yq1pnT0607JA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-3.0.0.tgz",
+      "integrity": "sha512-/SCQekZMJaTVANUelbXFfZGrmzFViLO4DieTtAI0J32kE6CobxtwQf4prfFSjRrT43vitaUuLgcuCSlpQWNycQ==",
       "requires": {
+        "@comunica/bindings-factory": "^2.0.1",
         "@rdfjs/types": "*",
+        "@types/lru-cache": "^5.1.1",
         "@types/spark-md5": "^3.0.2",
         "@types/uuid": "^8.0.0",
-        "decimal.js": "^10.2.0",
+        "bignumber.js": "^9.0.1",
         "hash.js": "^1.1.7",
-        "immutable": "^3.8.2",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0",
+        "lru-cache": "^6.0.0",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-string": "^1.6.3",
         "relative-to-absolute-iri": "^1.0.6",
         "spark-md5": "^3.0.1",
-        "sparqlalgebrajs": "^3.0.2",
+        "sparqlalgebrajs": "^4.2.0",
         "uuid": "^8.0.0"
       },
       "dependencies": {
-        "sparqlalgebrajs": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-          "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-          "requires": {
-            "@rdfjs/types": "*",
-            "@types/sparqljs": "^3.1.2",
-            "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-isomorphic": "^1.3.0",
-            "rdf-string": "^1.6.0",
-            "sparqljs": "^3.4.2"
-          }
+        "@types/lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -21995,56 +20744,45 @@
       }
     },
     "sparqljs": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.6.2.tgz",
-      "integrity": "sha512-KQEJPaOMeeDpdYYuiFb3JEErRLL8XqX4G7sdhZyHC6Qn4+PEMUff/EjUGkwcJ6aCC0JCTIgxDpRdE3+GFXpdxw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.1.tgz",
+      "integrity": "sha512-I1jYMtcwDkgCEqQ4eQuQIhB8hFAlRAJ6YDXDcV54XztaJaYRFqJlidHt77S3j8Mfh6kY6GK04dXPEIopxbEeuQ==",
       "requires": {
-        "rdf-data-factory": "^1.1.1"
+        "rdf-data-factory": "^1.1.2"
       }
     },
     "sparqljson-parse": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-1.7.0.tgz",
-      "integrity": "sha512-/88g7aK1QZ42YvMx+nStNeZsiVJhmg/OC4RNnQk+ybItvEkQiTOpnYDmST5FnzOIsSmp5RxAZDCIDdMK1h7Ynw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-2.2.0.tgz",
+      "integrity": "sha512-2TfvNvUsaJyWfCrq3ExdDdbF9LBLzIUCricg+D1YCYbbmyTzscgCtRk4KcIyJF178DtfCt4BkKzbKl8IXMHp8w==",
       "requires": {
+        "@bergos/jsonparse": "^1.4.1",
         "@rdfjs/types": "*",
-        "@types/node": "^13.1.0",
-        "JSONStream": "^1.3.3",
-        "rdf-data-factory": "^1.1.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
-        }
+        "@types/readable-stream": "^2.3.13",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
       }
     },
     "sparqljson-to-tree": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-2.1.0.tgz",
-      "integrity": "sha512-LwEMlrvjzEigatJ8iw1RKGWL9dKmATQNbTEXyadzsOQxbBhJNaGk8G9/WPCcVj2zlCPKGMysfNGb4UfvwHKeSw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-3.0.1.tgz",
+      "integrity": "sha512-WKDWCP6CM0Oa/OmzJJDpFudfa0yCcYnQoSPVb4RBp8XOYDOPn75fzrZURYQBSng/BUieT/zxaw68tstI6G3pSw==",
       "requires": {
         "rdf-literal": "^1.2.0",
-        "sparqljson-parse": "^1.6.0"
+        "sparqljson-parse": "^2.0.0"
       }
     },
     "sparqlxml-parse": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-1.5.0.tgz",
-      "integrity": "sha512-+0DCekgO3G6ugeVntrZS6+Fj60MsHR0q51WoRAdVzARb5V3jhX3dZJbwSaeydsOsXrtts4XSMc/z+kbqy5/VUQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-2.1.1.tgz",
+      "integrity": "sha512-71sltShF6gDAzuKWEHNeij7r0Mv5VqRrvJing6W4WHJ12GRe6+t1IRTv6MeqxYN3XJmKevs7B3HCBUo7wceeJQ==",
       "requires": {
         "@rdfjs/types": "*",
-        "@types/node": "^13.1.0",
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
         "rdf-data-factory": "^1.1.0",
-        "sax-stream": "^1.2.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
-        }
+        "readable-stream": "^4.0.0"
       }
     },
     "split-string": {
@@ -22075,6 +20813,11 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "static-extend": {
       "version": "0.1.2",
@@ -22152,9 +20895,9 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
     "stream-to-string": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.0.tgz",
-      "integrity": "sha512-8drZlFIKBHSMdX9GCWv8V9AAWnQcTqw0iAI6/GC7UJ0H0SwKeFKjOoZfGY1tOU00GGU7FYZQoJ/ZCUEoXhD7yQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.1.tgz",
+      "integrity": "sha512-WsvTDNF8UYs369Yko3pcdTducQtYpzEZeOV7cTuReyFvOoA9S/DLJ6sYK+xPafSPHhUMpaxiljKYnT6JSFztIA==",
       "requires": {
         "promise-polyfill": "^1.1.6"
       }
@@ -22183,6 +20926,18 @@
       "integrity": "sha512-Hl092MV3USJuUCC6mfl9sPzGloA3K5VwdIeJjYIkXY/8K+mUvaeEabWJgArp+xXrsWxCajeT2pc4axbVhIZJyg==",
       "requires": {
         "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "string-width": {
@@ -22193,6 +20948,16 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "string.prototype.trimend": {
@@ -22243,21 +21008,21 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "terser": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.2.tgz",
+      "integrity": "sha512-Ah19JS86ypbJzTzvUCX7KOsEIhDaRONungA4aYBjEP3JZRf4ocuDzTg4QWZnPn9DEMiMYGJPiSOy7aykoCc70w==",
       "peer": true,
       "requires": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
         "acorn": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+          "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
           "peer": true
         },
         "commander": {
@@ -22269,32 +21034,22 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
-      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
+      "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
       "peer": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.14",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.0",
-        "terser": "^5.14.1"
+        "serialize-javascript": "^6.0.1",
+        "terser": "^5.16.8"
       },
       "dependencies": {
-        "@jridgewell/trace-mapping": {
-          "version": "0.3.17",
-          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-          "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
-          "peer": true,
-          "requires": {
-            "@jridgewell/resolve-uri": "3.1.0",
-            "@jridgewell/sourcemap-codec": "1.4.14"
-          }
-        },
         "serialize-javascript": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-          "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+          "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
           "peer": true,
           "requires": {
             "randombytes": "^2.1.0"
@@ -22313,10 +21068,10 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    "tinyduration": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.3.0.tgz",
+      "integrity": "sha512-sLR0iVUnnnyGEX/a3jhTA0QMK7UvakBqQJFLiibiuEYL6U1L85W+qApTZj6DcL1uoWQntYuL0gExoe9NU5B3PA=="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -22380,14 +21135,19 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "ts-guards": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/ts-guards/-/ts-guards-0.5.1.tgz",
+      "integrity": "sha512-Y6P/VJnwARiPMfxO7rvaYaz5tGQ5TQ0Wnb2cWIxMpFOioYkhsT8XaCrJX6wYPNFACa4UOrN5SPqhwpM8NolAhQ=="
+    },
     "ts-morph": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-17.0.1.tgz",
-      "integrity": "sha512-10PkHyXmrtsTvZSL+cqtJLTgFXkU43Gd0JCc0Rw6GchWbqKe0Rwgt1v3ouobTZwQzF1mGhDeAlWYBMGRV7y+3g==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-19.0.0.tgz",
+      "integrity": "sha512-D6qcpiJdn46tUqV45vr5UGM2dnIEuTGNxVhg0sk5NX11orcouwj6i1bMqZIz2mZTZB1Hcgy7C3oEVhAT+f6mbQ==",
       "peer": true,
       "requires": {
-        "@ts-morph/common": "~0.18.0",
-        "code-block-writer": "^11.0.3"
+        "@ts-morph/common": "~0.20.0",
+        "code-block-writer": "^12.0.0"
       }
     },
     "ts-node": {
@@ -22412,9 +21172,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+          "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
           "peer": true
         }
       }
@@ -22423,6 +21183,11 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -22474,10 +21239,26 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      }
+    },
     "typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
+    },
+    "uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "optional": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -22555,9 +21336,9 @@
       }
     },
     "update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
       "peer": true,
       "requires": {
         "escalade": "^3.1.1",
@@ -22581,6 +21362,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg=="
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "use": {
       "version": "3.1.1",
@@ -22628,6 +21414,11 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "wac-allow": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wac-allow/-/wac-allow-1.0.0.tgz",
+      "integrity": "sha512-wKIb7+5HN3rsvXHq1D5BYaoYR0v+d6kkG/WZayCcpEP/+OpEx+zAYwRUABOjbELboirDRo9d6TOwNJ7AJLlSaQ=="
+    },
     "watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -22666,22 +21457,22 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.88.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
+      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
       "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^0.0.51",
-        "@webassemblyjs/ast": "1.11.1",
-        "@webassemblyjs/wasm-edit": "1.11.1",
-        "@webassemblyjs/wasm-parser": "1.11.1",
+        "@types/estree": "^1.0.0",
+        "@webassemblyjs/ast": "^1.11.5",
+        "@webassemblyjs/wasm-edit": "^1.11.5",
+        "@webassemblyjs/wasm-parser": "^1.11.5",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.7.6",
+        "acorn-import-assertions": "^1.9.0",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.10.0",
-        "es-module-lexer": "^0.9.0",
+        "enhanced-resolve": "^5.15.0",
+        "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
@@ -22690,30 +21481,30 @@
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.1.0",
+        "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.1.3",
+        "terser-webpack-plugin": "^5.3.7",
         "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },
       "dependencies": {
         "acorn": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+          "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
           "peer": true
         },
         "acorn-import-assertions": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-          "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+          "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
           "peer": true,
           "requires": {}
         },
         "enhanced-resolve": {
-          "version": "5.12.0",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
-          "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
+          "version": "5.15.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+          "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
           "peer": true,
           "requires": {
             "graceful-fs": "^4.2.4",
@@ -22782,10 +21573,23 @@
         "is-symbol": "^1.0.3"
       }
     },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      }
+    },
     "winston": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
-      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.9.0.tgz",
+      "integrity": "sha512-jW51iW/X95BCW6MMtZWr2jKQBP4hV5bIDq9QrIjfDk6Q9QuxvTKEAlpUNAzP+HYHFFCeENhph16s0zEunu4uuQ==",
       "requires": {
         "@colors/colors": "1.5.0",
         "@dabh/diagnostics": "^2.0.2",
@@ -22798,6 +21602,18 @@
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
         "winston-transport": "^4.5.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "winston-transport": {
@@ -22808,6 +21624,18 @@
         "logform": "^2.3.2",
         "readable-stream": "^3.6.0",
         "triple-beam": "^1.3.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "word-wrap": {
@@ -22815,6 +21643,11 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -22854,10 +21687,11 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
+    "ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "requires": {}
     },
     "xmlchars": {
       "version": "2.2.0",
@@ -22880,9 +21714,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "requires": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -22897,6 +21731,11 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+    },
+    "ylru": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.3.2.tgz",
+      "integrity": "sha512-RXRJzMiK6U2ye0BlGGZnmpwJDPgakn6aNQ0A7gHRbD4I0uvK4TW6UqkK1V0pp9jskjJBAXd3dRrbzWkqJ+6cxA=="
     },
     "yn": {
       "version": "3.1.1",

--- a/engine/package.json
+++ b/engine/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@inrupt/solid-client": "^1.23.3",
     "@rubensworks/solid-client-authn-isomorphic": "^2.0.0",
-    "@treecg/versionawareldesinldp": "^0.0.2",
+    "@solid/community-server": "^6.0.1",
+    "@treecg/versionawareldesinldp": "^0.2.1",
     "await-notify": "^1.0.1",
     "cors": "^2.8.5",
     "express": "^4.18.2",

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/


### PR DESCRIPTION
The versionawareldesinldp package was updated and it's dependancy with inrupt package was resolved. Thus, we don't need to delete the inrupt package manually from the node modules.